### PR TITLE
Add a skip link for the Blocks workspace

### DIFF
--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -28,6 +28,14 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
         this.showLanguagePicker = this.showLanguagePicker.bind(this);
         this.toggleHighContrast = this.toggleHighContrast.bind(this);
         this.goHome = this.goHome.bind(this);
+        this.openBlocks = this.openBlocks.bind(this);
+    }
+
+    openBlocks(e: React.MouseEvent<HTMLElement>) {
+        // Prevents "enter" from being handled again by Blockly's keyboard
+        // navigation plugin.
+        e.nativeEvent.stopPropagation()
+        this.props.parent.openBlocks();
     }
 
     openJavaScript() {
@@ -73,6 +81,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
         const hasHome = !pxt.shell.isControllerMode();
 
         return <div className="ui accessibleMenu borderless fixed menu" role="menubar">
+            {targetTheme.accessibleBlocks ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon blocks" text={lf("Skip to Blocks workspace")} onClick={this.openBlocks} /> : undefined}
             <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon js" text={lf("Skip to JavaScript editor")} onClick={this.openJavaScript} />
             {targetTheme.python ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon python" text={lf("Skip to Python editor")} onClick={this.openPython} /> : undefined}
             {targetTheme.selectLanguage ? <sui.Item className={`${targetTheme.invertedMenu ? `inverted` : ''} menu`} role="menuitem" icon="xicon globe" text={lf("Select Language")} onClick={this.showLanguagePicker} /> : undefined}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -664,6 +664,7 @@ export class ProjectView
 
         if (this.isBlocksActive()) {
             if (this.state.embedSimView) this.setState({ embedSimView: false });
+            this.editor.focusWorkspace();
             return;
         }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -44,7 +44,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     loadingXml: boolean;
     loadingXmlPromise: Promise<any>;
     compilationResult: pxtblockly.BlockCompilationResult;
-    isFirstBlocklyLoad = true;
+    isFirstLoad = true;
     functionsDialog: CreateFunctionDialog = null;
 
     showCategories: boolean = true;
@@ -159,6 +159,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             pxt.Util.toArray(document.querySelectorAll(classes)).forEach((el: HTMLElement) => el.style.display = 'none');
             if (this.editor) Blockly.hideChaff();
             if (this.toolbox) this.toolbox.clearExpandedItem();
+            // Update isFirstLoad here to handle when the app switches to JavaScript or Python immediately.
+            this.isFirstLoad = false;
         }
     }
 
@@ -226,7 +228,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
                     this.resize();
                     Blockly.svgResize(this.editor);
-                    this.isFirstBlocklyLoad = false;
+                    this.isFirstLoad = false;
                 }).finally(() => {
                     try {
                         // It's possible Blockly reloads and the loading dimmer is no longer a child of the editorDiv
@@ -320,6 +322,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.updateGrayBlocks();
 
             this.typeScriptSaveable = true;
+
+            if (!this.isFirstLoad) {
+                this.focusWorkspace();
+            }
         } catch (e) {
             pxt.log(e);
             pxtblockly.clearWithoutEvents(this.editor);
@@ -783,6 +789,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 width: window.innerWidth,
                 height: window.innerHeight
             });
+        }
+    }
+
+    focusWorkspace() {
+        if (pxt.appTarget.appTheme?.accessibleBlocks) {
+            (this.editor.getSvgGroup() as SVGElement).focus();
         }
     }
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -349,7 +349,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
 
 interface IBaseMenuItemProps extends ISettingsProps {
-    onClick: () => void;
+    onClick: (e: React.MouseEvent<HTMLElement>) => void;
     isActive: () => boolean;
 
     icon?: string;
@@ -413,7 +413,10 @@ class BlocksMenuItem extends data.Component<ISettingsProps, {}> {
         super(props);
     }
 
-    protected onClick = (): void => {
+    protected onClick = (e: React.MouseEvent<HTMLElement>): void => {
+        // Prevents "enter" from being handled again by Blockly's keyboard
+        // navigation plugin.
+        e.nativeEvent.stopPropagation()
         pxt.tickEvent("menu.blocks", undefined, { interactiveConsent: true });
         this.props.parent.openBlocks();
     }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1167,6 +1167,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         }
     }
 
+    focusWorkspace(): void {
+        this.editor.focus();
+    }
+
     undo() {
         if (!this.editor) return;
         this.editor.trigger('keyboard', 'undo', null);

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -149,6 +149,9 @@ export class Editor implements IEditor {
     focusToolbox(itemToFocus?: string) {
     }
 
+    focusWorkspace() {
+    }
+
     // allows all editors to send exceptions to error list
     onExceptionDetected(exception: pxsim.DebuggerBreakpointMessage) {
         core.warningNotification(lf("Program Error: {0}", exception?.exceptionMessage));


### PR DESCRIPTION
The Blocks workspace is also focussed when using the skip link or switching to Blocks when accessibleBlocks is enabled.