### PR TITLE
Remove unnecessary tab stops from toolbox

### DIFF
--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -65,7 +65,7 @@ div.blocklyTreeRoot > div[role="tree"] {
 }
 
 div.blocklyTreeRoot > div[role="tree"]:focus-visible {
-    outline: 3px auto #3454d1;
+    outline: 3px auto @mainMenuInvertedBackground;
 }
 
 /*******************************

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -58,6 +58,16 @@ div.blocklyTreeRoot:focus {
     outline: none;
 }
 
+div.blocklyTreeRoot > div[role="tree"] {
+    // Ensure that outline is shown over search input.
+    position: relative;
+    z-index: 1;
+}
+
+div.blocklyTreeRoot > div[role="tree"]:focus-visible {
+    outline: 3px auto #3454d1;
+}
+
 /*******************************
         Toolbox tree row
 *******************************/

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -4602,7 +4602,7 @@ export class ProjectView
             extensionsVisible: false
         })
 
-        if (this.state.accessibleBlocks) {
+        if (pxt.appTarget.appTheme.accessibleBlocks) {
             this.editor.focusToolbox(CategoryNameID.Extensions);
         }
     }
@@ -5243,7 +5243,8 @@ export class ProjectView
         const inDebugMode = this.state.debugging;
         const inHome = this.state.home && !sandbox;
         const inEditor = !!this.state.header && !inHome;
-        const { lightbox, greenScreen, accessibleBlocks } = this.state;
+        const { lightbox, greenScreen } = this.state;
+        const accessibleBlocks = pxt.appTarget.appTheme.accessibleBlocks;
         const hideTutorialIteration = inTutorial && tutorialOptions.metadata?.hideIteration;
         const hideToolbox = inTutorial && tutorialOptions.metadata?.hideToolbox;
         // flyoutOnly has become a de facto css class for styling tutorials (especially minecraft HOC), so keep it if hideToolbox is true, even if flyoutOnly is false.
@@ -5332,12 +5333,13 @@ export class ProjectView
                         header={this.state.header}
                         reloadHeaderAsync={async () => {
                             await this.reloadHeaderAsync()
-                            this.shouldFocusToolbox = !!this.state.accessibleBlocks;
+                            this.shouldFocusToolbox = !!accessibleBlocks;
                         }}
                     />
                 }
                 {greenScreen ? <greenscreen.WebCam close={this.toggleGreenScreen} /> : undefined}
-                {accessibleBlocks && <accessibleblocks.AccessibleBlocksInfo />}
+                {/* TODO: Discuss when this onboarding dialog should be shown if accessibleBlocks is enabled by default */}
+                {/* {accessibleBlocks && <accessibleblocks.AccessibleBlocksInfo />} */}
                 {hideMenuBar || inHome ? undefined :
                     <header className="menubar" role="banner">
                         {inEditor ? <accessibility.EditorAccessibilityMenu parent={this} highContrast={hc} /> : undefined}

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1660,7 +1660,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.flyoutXmlList.push(label);
         }
         this.showFlyoutInternal_(this.flyoutXmlList, "search");
-        this.toolbox.setSearch();
     }
 
     private showTopBlocksFlyout() {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -908,9 +908,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     public moveFocusToFlyout() {
         if (this.keyboardNavigation) {
             this.keyboardNavigation.focusFlyout();
-        } else {
-            // Move focus to the workspace. If Blockly change the flyout to be focussable this could focus it instead.
-            (this.editor.getInjectionDiv() as HTMLDivElement).focus();
         }
     }
 
@@ -1940,11 +1937,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     onToolboxFocusCapture(): void {
-        this.keyboardNavigation.onExternalToolboxFocus()
+        if (this.keyboardNavigation) {
+            this.keyboardNavigation.onExternalToolboxFocus()
+        }
     }
 
     onToolboxBlurCapture(): void {
-        this.keyboardNavigation.onExternalToolboxBlur()
+        if (this.keyboardNavigation) {
+            this.keyboardNavigation.onExternalToolboxBlur()
+        }
     }
 }
 

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -566,6 +566,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                 theEditor.showPackageDialog();
                 return true;
             },
+            onlyTriggerOnClick: true,
             attributes: {
                 advanced: false,
                 weight: -1,

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -272,7 +272,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         if (this.selectedItem && this.selectedItem.getTreeRow()) {
             // Focus the selected item
             const selectedItem = this.selectedItem.props.treeRow;
-            const selectedItemIndex = this.items.indexOf(selectedItem);
+            const selectedItemIndex = this.items.findIndex(item => item.nameid === selectedItem.nameid);
             this.setSelection(selectedItem, selectedItemIndex, true);
         } else {
             // Focus first item in the toolbox
@@ -473,7 +473,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
             if (this.selectedItem && this.selectedItem.getTreeRow()) {
                 // 'Focus' the selected item
                 const selectedItem = this.selectedItem.props.treeRow;
-                const selectedItemIndex = this.items.indexOf(selectedItem);
+                const selectedItemIndex = this.items.findIndex(item => item.nameid === selectedItem.nameid)
                 this.setSelection(selectedItem, selectedItemIndex, true);
             } else {
                 // 'Focus' first item in the toolbox
@@ -636,6 +636,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                         {hasSearch &&
                             <CategoryItem
                                 key={"search"}
+                                ref="searchCategory"
                                 toolbox={this}
                                 index={index++}
                                 selected={selectedItem == "search"}
@@ -1094,6 +1095,7 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
                 newState.focusSearch = true;
                 if (hasSearch) newState.selectedItem = 'search';
                 toolbox.setState(newState);
+                toolbox.setSelectedItem(toolbox.refs.searchCategory as CategoryItem)
 
                 this.setState({ searchAccessibilityLabel: searchAccessibilityLabel });
             });

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -130,7 +130,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     private selectedIndex: number;
     private items: ToolboxCategory[];
     private selectedTreeRow: ToolboxCategory;
-    private shouldHandleCategoryTreeFocus: boolean = true;
 
     constructor(props: ToolboxProps) {
         super(props);
@@ -266,25 +265,17 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     }
 
     focus(itemToFocus?: string) {
-        if (!this.rootElement) return;
-        this.shouldHandleCategoryTreeFocus = false;
-        (this.refs.categoryTree as HTMLDivElement).focus();
-        if (this.selectedItem && this.selectedItem.getTreeRow()) {
-            // Focus the selected item
-            const selectedItem = this.selectedItem.props.treeRow;
-            const selectedItemIndex = this.items.findIndex(item => item.nameid === selectedItem.nameid);
-            this.setSelection(selectedItem, selectedItemIndex, true);
-        } else {
-            // Focus first item in the toolbox
-            if (itemToFocus) {
-                for (const item of this.items) {
-                    if (item.nameid === itemToFocus) {
-                        this.setSelection(item, this.items.indexOf(item), true);
-                        return;
-                    }
+        if (itemToFocus) {
+            for (const item of this.items) {
+                if (item.nameid === itemToFocus) {
+                    this.setSelection(item, this.items.indexOf(item), true);
+                    return;
                 }
             }
-            this.selectFirstItem();
+        } else {
+            // If there is not a specific item to focus, the handleCategoryTreeFocus focus
+            // handler will highlight the currently selected item if it exists, else the first item.
+            (this.refs.categoryTree as HTMLDivElement).focus()
         }
     }
 
@@ -468,7 +459,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     handleCategoryTreeFocus = (e: React.FocusEvent<HTMLDivElement>) => {
         // Don't handle focus on a mouse down event when the relatedTarget is null.
         // Rely on the click handler instead.
-        if (this.shouldHandleCategoryTreeFocus && e.relatedTarget) {
+        if (e.relatedTarget) {
             if (!this.rootElement) return;
             if (this.selectedItem && this.selectedItem.getTreeRow()) {
                 // 'Focus' the selected item
@@ -480,7 +471,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                 this.selectFirstItem();
             }
         }
-        this.shouldHandleCategoryTreeFocus = true;
     }
 
     isRtl() {

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -130,6 +130,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     private selectedIndex: number;
     private items: ToolboxCategory[];
     private selectedTreeRow: ToolboxCategory;
+    private shouldHandleCategoryTreeFocus: boolean = true;
 
     constructor(props: ToolboxProps) {
         super(props);
@@ -147,6 +148,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         this.handleRemoveExtension = this.handleRemoveExtension.bind(this);
         this.deleteExtension = this.deleteExtension.bind(this);
         this.cancelDeleteExtension= this.cancelDeleteExtension.bind(this);
+        this.handleKeyDown = this.handleKeyDown.bind(this);
     }
 
     getElement() {
@@ -265,6 +267,8 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
 
     focus(itemToFocus?: string) {
         if (!this.rootElement) return;
+        this.shouldHandleCategoryTreeFocus = false;
+        (this.refs.categoryTree as HTMLDivElement).focus();
         if (this.selectedItem && this.selectedItem.getTreeRow()) {
             // Focus the selected item
             const selectedItem = this.selectedItem.props.treeRow;
@@ -461,9 +465,83 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         this.props.parent.onToolboxBlurCapture();
     }
 
+    handleCategoryTreeFocus = (e: React.FocusEvent<HTMLDivElement>) => {
+        // Don't handle focus on a mouse down event when the relatedTarget is null.
+        // Rely on the click handler instead.
+        if (this.shouldHandleCategoryTreeFocus && e.relatedTarget) {
+            if (!this.rootElement) return;
+            if (this.selectedItem && this.selectedItem.getTreeRow()) {
+                // 'Focus' the selected item
+                const selectedItem = this.selectedItem.props.treeRow;
+                const selectedItemIndex = this.items.indexOf(selectedItem);
+                this.setSelection(selectedItem, selectedItemIndex, true);
+            } else {
+                // 'Focus' first item in the toolbox
+                this.selectFirstItem();
+            }
+        }
+        this.shouldHandleCategoryTreeFocus = true;
+    }
+
     isRtl() {
         const { editorname } = this.props;
         return editorname == 'monaco' ? false : Util.isUserLanguageRtl();
+    }
+
+    handleKeyDown(e: React.KeyboardEvent<HTMLElement>) {
+        const isRtl = Util.isUserLanguageRtl();
+
+        const mainWorkspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+        // This prevents accidental toolbox navigation while the navigation cursor
+        // is in the flyout. This is needed because the flyout doesn't take the focus.
+        const toolboxNavigationEnabled = !mainWorkspace.keyboardAccessibilityMode;
+        const charCode = core.keyCodeFromEvent(e);
+        if (toolboxNavigationEnabled) {
+            if (charCode == 40 /* Down arrow key */) {
+                this.nextItem();
+            } else if (charCode == 38 /* Up arrow key */) {
+                this.previousItem();
+            } else if ((charCode == 39 /* Right arrow key */ && !isRtl)
+                || (charCode == 37 /* Left arrow key */ && isRtl)) {
+                    if (this.selectedTreeRow.nameid !== "addpackage") {
+                        // Focus inside flyout
+                        this.moveFocusToFlyout();
+                    }
+            } else if (charCode == 27) { // ESCAPE
+                // Close the flyout
+                this.closeFlyout();
+            } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
+                const {onCategoryClick, treeRow, index} = this.selectedItem.props;
+                if (onCategoryClick) {
+                    onCategoryClick(treeRow, index);
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            } else if (charCode == core.TAB_KEY
+                || charCode == 37 /* Left arrow key */
+                || charCode == 39 /* Right arrow key */
+                || charCode == 17 /* Ctrl Key */
+                || charCode == 16 /* Shift Key */
+                || charCode == 91 /* Cmd Key */) {
+                // Escape tab and shift key
+            } else {
+                this.setSearch();
+            }
+        }
+    }
+
+    previousItem() {
+        const editorname = this.props.editorname;
+
+        pxt.tickEvent(`${editorname}.toolbox.keyboard.prev"`, undefined, { interactiveConsent: true });
+        this.setPreviousItem();
+    }
+
+    nextItem() {
+        const editorname = this.props.editorname;
+
+        pxt.tickEvent(`${editorname}.toolbox.keyboard.next"`, undefined, { interactiveConsent: true });
+        this.setNextItem();
     }
 
     renderCore() {
@@ -553,7 +631,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                     />
                 }
                 <div className="blocklyTreeRoot">
-                    <div role="tree">
+                    <div role="tree" tabIndex={0} ref="categoryTree" onFocus={this.handleCategoryTreeFocus} onKeyDown={this.handleKeyDown}>
                         {tryToDeleteNamespace &&
                             <DeleteConfirmationModal
                                 ns={tryToDeleteNamespace}
@@ -625,10 +703,11 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                                 />
                             </>
                         }
-                        {showAdvanced &&
+                        {
                             advancedCategories.map(treeRow =>
                                 <CategoryItem
                                     key={treeRow.nameid}
+                                    className={!showAdvanced && "hidden"}
                                     toolbox={this}
                                     index={index++}
                                     selected={selectedItem == treeRow.nameid}
@@ -666,6 +745,7 @@ export interface CategoryItemProps extends TreeRowProps {
     topRowIndex?: number;
     hasDeleteButton?: boolean;
     onDeleteClick?: (ns: string) => void;
+    className?: string;
 }
 
 export interface CategoryItemState {
@@ -682,7 +762,6 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         }
 
         this.handleClick = this.handleClick.bind(this);
-        this.handleKeyDown = this.handleKeyDown.bind(this);
     }
 
     getTreeRow() {
@@ -717,75 +796,22 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
         e.stopPropagation();
     }
 
-    handleKeyDown(e: React.KeyboardEvent<HTMLElement>) {
-        const { toolbox } = this.props;
-        const isRtl = Util.isUserLanguageRtl();
-
-        const mainWorkspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-        // This prevents accidental toolbox navigation while the navigation cursor
-        // is in the flyout. This is needed because the flyout doesn't take the focus.
-        const toolboxNavigationEnabled = !mainWorkspace.keyboardAccessibilityMode;
-        const charCode = core.keyCodeFromEvent(e);
-        if (toolboxNavigationEnabled) {
-            if (charCode == 40 /* Down arrow key */) {
-                this.nextItem();
-            } else if (charCode == 38 /* Up arrow key */) {
-                this.previousItem();
-            } else if ((charCode == 39 /* Right arrow key */ && !isRtl)
-                || (charCode == 37 /* Left arrow key */ && isRtl)) {
-                // Focus inside flyout
-                toolbox.moveFocusToFlyout();
-            } else if (charCode == 27) { // ESCAPE
-                // Close the flyout
-                toolbox.closeFlyout();
-            } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
-                fireClickOnEnter.call(this, e);
-            } else if (charCode == core.TAB_KEY
-                || charCode == 37 /* Left arrow key */
-                || charCode == 39 /* Right arrow key */
-                || charCode == 17 /* Ctrl Key */
-                || charCode == 16 /* Shift Key */
-                || charCode == 91 /* Cmd Key */) {
-                // Escape tab and shift key
-            } else {
-                toolbox.setSearch();
-            }
-        }
-    }
-
-    previousItem() {
-        const { toolbox } = this.props;
-        const editorname = toolbox.props.editorname;
-
-        pxt.tickEvent(`${editorname}.toolbox.keyboard.prev"`, undefined, { interactiveConsent: true });
-        toolbox.setPreviousItem();
-    }
-
-    nextItem() {
-        const { toolbox } = this.props;
-        const editorname = toolbox.props.editorname;
-
-        pxt.tickEvent(`${editorname}.toolbox.keyboard.next"`, undefined, { interactiveConsent: true });
-        toolbox.setNextItem();
-    }
-
-    handleTreeRowRef = (c: TreeRow) => {
+     handleTreeRowRef = (c: TreeRow) => {
         this.treeRowElement = c;
     }
 
     renderCore() {
-        const { toolbox, childrenVisible, hasDeleteButton } = this.props;
+        const { toolbox, childrenVisible, hasDeleteButton, className } = this.props;
         const { selected } = this.state;
 
         return (
-            <TreeItem>
+            <TreeItem className={className}>
                 <TreeRow
                     ref={this.handleTreeRowRef}
                     isRtl={toolbox.isRtl()}
                     {...this.props}
                     selected={selected}
                     onClick={this.handleClick}
-                    onKeyDown={this.handleKeyDown}
                     hasDeleteButton={hasDeleteButton}
                 />
                 <TreeGroup visible={childrenVisible}>
@@ -920,7 +946,6 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
                 ref={this.handleTreeRowRef}
                 className={treeRowClass}
                 style={treeRowStyle}
-                tabIndex={0}
                 data-ns={dataNs}
                 aria-label={lf("Toggle category {0}", rowTitle)}
                 aria-expanded={selected}
@@ -964,14 +989,15 @@ export class TreeSeparator extends data.Component<{}, {}> {
 
 export interface TreeItemProps {
     selected?: boolean;
+    className?: string;
     children?: any;
 }
 
 export class TreeItem extends data.Component<TreeItemProps, {}> {
     renderCore() {
-        const { selected } = this.props;
+        const { selected, className } = this.props;
         return (
-            <div role="treeitem" aria-selected={selected}>
+            <div className={classList(className)} role="treeitem" aria-selected={selected}>
                 {this.props.children}
             </div>
         );
@@ -1039,8 +1065,9 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
         const { toolbox } = this.props;
         let charCode = (typeof e.which == "number") ? e.which : e.keyCode
         if (charCode === 40 /* Down Key */) {
-            // Select first item in the toolbox
-            toolbox.selectFirstItem();
+            // Focus the toolbox category tree which opens the currently selected
+            // item if one exists, or the first item.
+            (toolbox.refs.categoryTree as HTMLDivElement).focus()
         }
     }
 

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -491,42 +491,36 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     handleKeyDown(e: React.KeyboardEvent<HTMLElement>) {
         const isRtl = Util.isUserLanguageRtl();
 
-        const mainWorkspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-        // This prevents accidental toolbox navigation while the navigation cursor
-        // is in the flyout. This is needed because the flyout doesn't take the focus.
-        const toolboxNavigationEnabled = !mainWorkspace.keyboardAccessibilityMode;
         const charCode = core.keyCodeFromEvent(e);
-        if (toolboxNavigationEnabled) {
-            if (charCode == 40 /* Down arrow key */) {
-                this.nextItem();
-            } else if (charCode == 38 /* Up arrow key */) {
-                this.previousItem();
-            } else if ((charCode == 39 /* Right arrow key */ && !isRtl)
-                || (charCode == 37 /* Left arrow key */ && isRtl)) {
-                    if (this.selectedTreeRow.nameid !== "addpackage") {
-                        // Focus inside flyout
-                        this.moveFocusToFlyout();
-                    }
-            } else if (charCode == 27) { // ESCAPE
-                // Close the flyout
-                this.closeFlyout();
-            } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
-                const {onCategoryClick, treeRow, index} = this.selectedItem.props;
-                if (onCategoryClick) {
-                    onCategoryClick(treeRow, index);
-                    e.preventDefault();
-                    e.stopPropagation();
+        if (charCode == 40 /* Down arrow key */) {
+            this.nextItem();
+        } else if (charCode == 38 /* Up arrow key */) {
+            this.previousItem();
+        } else if ((charCode == 39 /* Right arrow key */ && !isRtl)
+            || (charCode == 37 /* Left arrow key */ && isRtl)) {
+                if (this.selectedTreeRow.nameid !== "addpackage") {
+                    // Focus inside flyout
+                    this.moveFocusToFlyout();
                 }
-            } else if (charCode == core.TAB_KEY
-                || charCode == 37 /* Left arrow key */
-                || charCode == 39 /* Right arrow key */
-                || charCode == 17 /* Ctrl Key */
-                || charCode == 16 /* Shift Key */
-                || charCode == 91 /* Cmd Key */) {
-                // Escape tab and shift key
-            } else {
-                this.setSearch();
+        } else if (charCode == 27) { // ESCAPE
+            // Close the flyout
+            this.closeFlyout();
+        } else if (charCode == core.ENTER_KEY || charCode == core.SPACE_KEY) {
+            const {onCategoryClick, treeRow, index} = this.selectedItem.props;
+            if (onCategoryClick) {
+                onCategoryClick(treeRow, index);
+                e.preventDefault();
+                e.stopPropagation();
             }
+        } else if (charCode == core.TAB_KEY
+            || charCode == 37 /* Left arrow key */
+            || charCode == 39 /* Right arrow key */
+            || charCode == 17 /* Ctrl Key */
+            || charCode == 16 /* Shift Key */
+            || charCode == 91 /* Cmd Key */) {
+            // Escape tab and shift key
+        } else {
+            this.setSearch();
         }
     }
 


### PR DESCRIPTION
- Instead of toolbox categories taking focus, use focus on the parent tree element alongside existing key handling. 
- Advanced categories are now always in the dom but hidden using CSS to fix toolbox-Blockly interactions.
- Simplify the toolbox handleKeyDown function so that key events are always handled after changes in the way the Blockly keyboard navigation plugin manages focus. The previous work unintentional broke keyboard navigation in the JavaScript/Monaco toolbox implementation.