### PR TITLE
(User testing only) Keyboard accessibility for the imagedropdown and images fields

### DIFF
--- a/pxtblocks/fields/field_images.ts
+++ b/pxtblocks/fields/field_images.ts
@@ -27,7 +27,7 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
      * Create a dropdown menu under the text.
      * @private
      */
-    public showEditor_() {
+    public showEditor_(e?: MouseEvent) {
         // If there is an existing drop-down we own, this is a request to hide the drop-down.
         if (Blockly.DropDownDiv.hideIfOwner(this)) {
             return;
@@ -40,10 +40,13 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
         let dropdownDiv = Blockly.DropDownDiv.getContentDiv();
         let contentDiv = document.createElement('div');
         // Accessibility properties
-        contentDiv.setAttribute('role', 'menu');
-        contentDiv.setAttribute('aria-haspopup', 'true');
+        contentDiv.setAttribute('role', 'grid');
+        contentDiv.setAttribute('tabindex', '0');
+        contentDiv.setAttribute('class', 'blocklyMenu blocklyImageMenu');
+        this.addKeyHandler(contentDiv)
         const options = this.getOptions();
         if (this.shouldSort_) options.sort();
+        let row = this.createRow();
         for (let i = 0; i < options.length; i++) {
             const content = (options[i] as any)[0]; // Human-readable text or image.
             const value = (options[i] as any)[1]; // Language-neutral value.
@@ -57,9 +60,12 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
                 contentDiv.appendChild(placeholder);
                 continue;
             }
-            let button = document.createElement('button');
+            const buttonContainer = document.createElement('div');
+            buttonContainer.setAttribute('class', 'blocklyDropDownButtonContainer')
+            let button = document.createElement('div');
             button.setAttribute('id', ':' + i); // For aria-activedescendant
-            button.setAttribute('role', 'menuitem');
+            button.setAttribute('role', 'gridcell');
+            button.setAttribute('aria-selected', 'false');
             button.setAttribute('class', 'blocklyDropDownButton');
             button.title = content.alt;
             if ((this as any).columns_) {
@@ -74,17 +80,23 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
                 // This icon is selected, show it in a different colour
                 backgroundColor = sourceBlock.getColourTertiary();
                 button.setAttribute('aria-selected', 'true');
+                this.activeDescendantIndex = i;
+                contentDiv.setAttribute('aria-activedescendant', button.id);
+                button.setAttribute('class', `blocklyDropDownButton ${e ? "blocklyDropDownButtonHover" : "blocklyDropDownButtonFocus"}`);
             }
             button.style.backgroundColor = backgroundColor;
             button.style.borderColor = sourceBlock.getColourTertiary();
-            Blockly.browserEvents.bind(button, 'click', this, this.buttonClick_);
+            Blockly.browserEvents.bind(button, 'click', this, () => this.buttonClick_(value));
             Blockly.browserEvents.bind(button, 'mouseover', this, () => {
+                this.buttons.forEach(button => button.setAttribute('class', 'blocklyDropDownButton'));
+                this.activeDescendantIndex = i;
                 button.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
                 contentDiv.setAttribute('aria-activedescendant', button.id);
             });
             Blockly.browserEvents.bind(button, 'mouseout', this, () => {
                 button.setAttribute('class', 'blocklyDropDownButton');
                 contentDiv.removeAttribute('aria-activedescendant');
+                this.activeDescendantIndex = undefined;
             });
             let buttonImg = document.createElement('img');
             buttonImg.src = content.src;
@@ -99,7 +111,16 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
                 buttonText.setAttribute('data-value', value);
                 button.appendChild(buttonText);
             }
-            contentDiv.appendChild(button);
+            this.buttons.push(button);
+            buttonContainer.appendChild(button)
+            row.append(buttonContainer)
+            if (row.childElementCount === this.columns_) {
+                contentDiv.appendChild(row);
+                row = this.createRow();
+            }
+        }
+        if (row.childElementCount) {
+            contentDiv.appendChild(row);
         }
         contentDiv.style.width = (this as any).width_ + 'px';
         dropdownDiv.appendChild(contentDiv);
@@ -108,6 +129,8 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
 
         // Position based on the field position.
         Blockly.DropDownDiv.showPositionedByField(this, this.onHideCallback.bind(this));
+
+        contentDiv.focus();
 
         // Update colour to look selected.
         this.savedPrimary_ = sourceBlock?.getColour();
@@ -120,6 +143,11 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
 
     // Update color (deselect) on dropdown hide
     protected onHideCallback() {
+        const content = Blockly.DropDownDiv.getContentDiv() as HTMLElement;
+        content.removeAttribute('role');
+        content.removeAttribute('aria-activedescendant');
+        this.activeDescendantIndex = undefined;
+        this.buttons = [];
         let source = this.sourceBlock_ as Blockly.BlockSvg;
         if (source?.isShadow()) {
             source.setColour(this.savedPrimary_);
@@ -135,3 +163,15 @@ export class FieldImages extends FieldImageDropdown implements FieldCustom {
         return textSpan;
     }
 }
+
+Blockly.Css.register(`
+.blocklyImageMenu .blocklyDropDownButton > img {
+    top: unset;
+    transform: unset;
+    margin-top: 4px;
+}
+.blocklyImageMenu .blocklyDropdownTextLabel {
+    line-height: 1.15;
+    margin-top: 2px;
+}
+`)


### PR DESCRIPTION
We intend to merge this into a user testing branch only. The longer term plan is to move these fields over from extending Blockly's dropdown field to extending Blockly's grid field after [recent improvements to the keyboard navigation](https://github.com/google/blockly-samples/pull/2488) for that field.

We are still waiting for the grid field to be more open to the types of items it can take, see https://github.com/google/blockly-samples/issues/2482.