### PR TITLE
[DRAFT - DO NOT MERGE] Use Blockly grid dropdown plugin

### DIFF
--- a/pxtblocks/fields/field_imagedropdown.ts
+++ b/pxtblocks/fields/field_imagedropdown.ts
@@ -2,7 +2,7 @@
 
 import * as Blockly from "blockly";
 import { FieldCustom, FieldCustomDropdownOptions, parseColour } from "./field_utils";
-import { FieldDropdown } from "./field_dropdown";
+import { FieldGridDropdown } from "@blockly/field-grid-dropdown";
 
 export interface FieldImageDropdownOptions extends FieldCustomDropdownOptions {
     columns?: string;
@@ -10,7 +10,7 @@ export interface FieldImageDropdownOptions extends FieldCustomDropdownOptions {
     width?: string;
 }
 
-export class FieldImageDropdown extends FieldDropdown implements FieldCustom {
+export class FieldImageDropdown extends FieldGridDropdown implements FieldCustom {
     public isFieldCustom_ = true;
     // Width in pixels
     protected width_: number;
@@ -27,7 +27,8 @@ export class FieldImageDropdown extends FieldDropdown implements FieldCustom {
     protected savedPrimary_: string;
 
     constructor(text: string, options: FieldImageDropdownOptions, validator?: Function) {
-        super(options.data);
+        console.log(options.data)
+        super(options.data, undefined, {columns: parseInt(options.columns)});
 
         this.columns_ = parseInt(options.columns);
         this.maxRows_ = parseInt(options.maxRows) || 0;
@@ -42,102 +43,103 @@ export class FieldImageDropdown extends FieldDropdown implements FieldCustom {
      * @private
      */
     public showEditor_() {
-        // If there is an existing drop-down we own, this is a request to hide the drop-down.
-        if (Blockly.DropDownDiv.hideIfOwner(this)) {
-            return;
-        }
-        // If there is an existing drop-down someone else owns, hide it immediately and clear it.
-        Blockly.DropDownDiv.hideWithoutAnimation();
-        Blockly.DropDownDiv.clearContent();
-        // Populate the drop-down with the icons for this field.
-        let dropdownDiv = Blockly.DropDownDiv.getContentDiv() as HTMLElement;
-        let contentDiv = document.createElement('div');
-        // Accessibility properties
-        contentDiv.setAttribute('role', 'menu');
-        contentDiv.setAttribute('aria-haspopup', 'true');
-        const options = this.getOptions();
-        let maxButtonHeight: number = 0;
-        for (let i = 0; i < options.length; i++) {
-            let content = (options[i] as any)[0]; // Human-readable text or image.
-            const value = (options[i] as any)[1]; // Language-neutral value.
-            // Icons with the type property placeholder take up space but don't have any functionality
-            // Use for special-case layouts
-            if (content.type == 'placeholder') {
-                let placeholder = document.createElement('span');
-                placeholder.setAttribute('class', 'blocklyDropDownPlaceholder');
-                placeholder.style.width = content.width + 'px';
-                placeholder.style.height = content.height + 'px';
-                contentDiv.appendChild(placeholder);
-                continue;
-            }
-            let button = document.createElement('button');
-            button.setAttribute('id', ':' + i); // For aria-activedescendant
-            button.setAttribute('role', 'menuitem');
-            button.setAttribute('class', 'blocklyDropDownButton');
-            button.title = content.alt;
-            let buttonSize = content.height;
-            if (this.columns_) {
-                buttonSize = ((this.width_ / this.columns_) - 8);
-                button.style.width = buttonSize + 'px';
-                button.style.height = buttonSize + 'px';
-            } else {
-                button.style.width = content.width + 'px';
-                button.style.height = content.height + 'px';
-            }
-            if (buttonSize > maxButtonHeight) {
-                maxButtonHeight = buttonSize;
-            }
-            let backgroundColor = this.backgroundColour_;
-            if (value == this.getValue()) {
-                // This icon is selected, show it in a different colour
-                backgroundColor = (this.sourceBlock_ as Blockly.BlockSvg).getColourTertiary();
-                button.setAttribute('aria-selected', 'true');
-            }
-            button.style.backgroundColor = backgroundColor;
-            button.style.borderColor = this.borderColour_;
-            Blockly.browserEvents.bind(button, 'click', this, this.buttonClick_);
-            Blockly.browserEvents.bind(button, 'mouseover', this, () => {
-                button.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
-                contentDiv.setAttribute('aria-activedescendant', button.id);
-            });
-            Blockly.browserEvents.bind(button, 'mouseout', this, () => {
-                button.setAttribute('class', 'blocklyDropDownButton');
-                contentDiv.removeAttribute('aria-activedescendant');
-            });
-            let buttonImg = document.createElement('img');
-            buttonImg.src = content.src;
-            //buttonImg.alt = icon.alt;
-            // Upon click/touch, we will be able to get the clicked element as e.target
-            // Store a data attribute on all possible click targets so we can match it to the icon.
-            button.setAttribute('data-value', value);
-            buttonImg.setAttribute('data-value', value);
-            button.appendChild(buttonImg);
-            contentDiv.appendChild(button);
-        }
-        contentDiv.style.width = this.width_ + 'px';
-        dropdownDiv.appendChild(contentDiv);
-        if (this.maxRows_) {
-            // Limit the number of rows shown, but add a partial next row to indicate scrolling
-            dropdownDiv.style.maxHeight = (this.maxRows_ + 0.4) * (maxButtonHeight + 8) + 'px';
-        }
+        super.showEditor_();
+        // // If there is an existing drop-down we own, this is a request to hide the drop-down.
+        // if (Blockly.DropDownDiv.hideIfOwner(this)) {
+        //     return;
+        // }
+        // // If there is an existing drop-down someone else owns, hide it immediately and clear it.
+        // Blockly.DropDownDiv.hideWithoutAnimation();
+        // Blockly.DropDownDiv.clearContent();
+        // // Populate the drop-down with the icons for this field.
+        // let dropdownDiv = Blockly.DropDownDiv.getContentDiv() as HTMLElement;
+        // let contentDiv = document.createElement('div');
+        // // Accessibility properties
+        // contentDiv.setAttribute('role', 'menu');
+        // contentDiv.setAttribute('aria-haspopup', 'true');
+        // const options = this.getOptions();
+        // let maxButtonHeight: number = 0;
+        // for (let i = 0; i < options.length; i++) {
+        //     let content = (options[i] as any)[0]; // Human-readable text or image.
+        //     const value = (options[i] as any)[1]; // Language-neutral value.
+        //     // Icons with the type property placeholder take up space but don't have any functionality
+        //     // Use for special-case layouts
+        //     if (content.type == 'placeholder') {
+        //         let placeholder = document.createElement('span');
+        //         placeholder.setAttribute('class', 'blocklyDropDownPlaceholder');
+        //         placeholder.style.width = content.width + 'px';
+        //         placeholder.style.height = content.height + 'px';
+        //         contentDiv.appendChild(placeholder);
+        //         continue;
+        //     }
+        //     let button = document.createElement('button');
+        //     button.setAttribute('id', ':' + i); // For aria-activedescendant
+        //     button.setAttribute('role', 'menuitem');
+        //     button.setAttribute('class', 'blocklyDropDownButton');
+        //     button.title = content.alt;
+        //     let buttonSize = content.height;
+        //     if (this.columns_) {
+        //         buttonSize = ((this.width_ / this.columns_) - 8);
+        //         button.style.width = buttonSize + 'px';
+        //         button.style.height = buttonSize + 'px';
+        //     } else {
+        //         button.style.width = content.width + 'px';
+        //         button.style.height = content.height + 'px';
+        //     }
+        //     if (buttonSize > maxButtonHeight) {
+        //         maxButtonHeight = buttonSize;
+        //     }
+        //     let backgroundColor = this.backgroundColour_;
+        //     if (value == this.getValue()) {
+        //         // This icon is selected, show it in a different colour
+        //         backgroundColor = (this.sourceBlock_ as Blockly.BlockSvg).getColourTertiary();
+        //         button.setAttribute('aria-selected', 'true');
+        //     }
+        //     button.style.backgroundColor = backgroundColor;
+        //     button.style.borderColor = this.borderColour_;
+        //     Blockly.browserEvents.bind(button, 'click', this, this.buttonClick_);
+        //     Blockly.browserEvents.bind(button, 'mouseover', this, () => {
+        //         button.setAttribute('class', 'blocklyDropDownButton blocklyDropDownButtonHover');
+        //         contentDiv.setAttribute('aria-activedescendant', button.id);
+        //     });
+        //     Blockly.browserEvents.bind(button, 'mouseout', this, () => {
+        //         button.setAttribute('class', 'blocklyDropDownButton');
+        //         contentDiv.removeAttribute('aria-activedescendant');
+        //     });
+        //     let buttonImg = document.createElement('img');
+        //     buttonImg.src = content.src;
+        //     //buttonImg.alt = icon.alt;
+        //     // Upon click/touch, we will be able to get the clicked element as e.target
+        //     // Store a data attribute on all possible click targets so we can match it to the icon.
+        //     button.setAttribute('data-value', value);
+        //     buttonImg.setAttribute('data-value', value);
+        //     button.appendChild(buttonImg);
+        //     contentDiv.appendChild(button);
+        // }
+        // contentDiv.style.width = this.width_ + 'px';
+        // dropdownDiv.appendChild(contentDiv);
+        // if (this.maxRows_) {
+        //     // Limit the number of rows shown, but add a partial next row to indicate scrolling
+        //     dropdownDiv.style.maxHeight = (this.maxRows_ + 0.4) * (maxButtonHeight + 8) + 'px';
+        // }
 
-        if (pxt.BrowserUtils.isFirefox()) {
-            // This is to compensate for the scrollbar that overlays content in Firefox. It
-            // gets removed in onHide_()
-            dropdownDiv.style.paddingRight = "20px";
-        }
+        // if (pxt.BrowserUtils.isFirefox()) {
+        //     // This is to compensate for the scrollbar that overlays content in Firefox. It
+        //     // gets removed in onHide_()
+        //     dropdownDiv.style.paddingRight = "20px";
+        // }
 
-        Blockly.DropDownDiv.setColour(this.backgroundColour_, this.borderColour_);
+        // Blockly.DropDownDiv.setColour(this.backgroundColour_, this.borderColour_);
 
-        Blockly.DropDownDiv.showPositionedByField(this, this.onHide_.bind(this));
+        // Blockly.DropDownDiv.showPositionedByField(this, this.onHide_.bind(this));
 
-        let source = this.sourceBlock_ as Blockly.BlockSvg;
-        this.savedPrimary_ = source?.getColour();
-        if (source?.isShadow()) {
-            source.setColour(source.getColourTertiary());
-        } else if (this.borderRect_) {
-            this.borderRect_.setAttribute('fill', source.getColourTertiary());
-        }
+        // let source = this.sourceBlock_ as Blockly.BlockSvg;
+        // this.savedPrimary_ = source?.getColour();
+        // if (source?.isShadow()) {
+        //     source.setColour(source.getColourTertiary());
+        // } else if (this.borderRect_) {
+        //     this.borderRect_.setAttribute('fill', source.getColourTertiary());
+        // }
     }
 
     doValueUpdate_(newValue: any): void {


### PR DESCRIPTION
A potential (low effort?) alternative to https://github.com/microbit-matt-hillsdon/pxt/pull/8

The grid items look a bit odd due to a mixture of CSS that could be easily tweaked and the img attributes that MakeCode supply being taken seriously. The image data provided to the field editor is with [height and width at 36px](https://github.com/microsoft/pxt/blob/master/pxtblocks/loader.ts#L446-L447) which is not straight forward to fix with CSS overrides as MakeCode normally uses 80% for this value rather than a hardcoded value in pixels.