### PR TITLE
Fix category scroll into view bug

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -897,6 +897,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         return blocksArea ? blocksArea.getElementsByClassName('blocklyToolboxDiv')[0] as HTMLDivElement : undefined;
     }
 
+    getToolboxDiv(): HTMLDivElement {
+        return this.getBlocklyToolboxDiv();
+    }
+
     handleToolboxRef = (c: toolbox.Toolbox) => {
         this.toolbox = c;
     }

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -816,6 +816,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         return false;
     }
 
+    getToolboxDiv(): HTMLElement | undefined {
+        const monacoArea = document.getElementById('monacoEditorArea');
+        if (!monacoArea) return undefined;
+        return monacoArea.getElementsByClassName('monacoToolboxDiv')[0] as HTMLElement;
+    }
+
     resize(e?: Event) {
         let monacoArea = document.getElementById('monacoEditorArea');
         if (!monacoArea) return;

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -80,6 +80,10 @@ export class Editor implements IEditor {
         return false
     }
 
+    getToolboxDiv(): HTMLElement | undefined {
+        return undefined;
+    }
+
     hasHistory() { return true; }
     hasUndo() { return true; }
     hasRedo() { return true; }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -777,7 +777,17 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
             this.props.toolbox.setSelectedItem(this);
             if (!toolbox.state.focusSearch && !coretsx.dialogIsShowing()) {
                 this.focusElement();
-                this.scrollElementIntoView({block: this.props.index === 0 || prevProps.selectedIndex < this.props.index ? "end" : "start"});
+                const activeCategoryRect = this.getBoundingClientRect();
+                toolbox.props.parent.getToolboxDiv()
+                const toolboxRect = toolbox.props.parent.getToolboxDiv()?.getBoundingClientRect();
+                if (!toolboxRect) {
+                    return;
+                }
+                if (activeCategoryRect.bottom > toolboxRect.bottom) {
+                    this.scrollElementIntoView({block: "end"});
+                } else if (activeCategoryRect.top < toolboxRect.top) {
+                    this.scrollElementIntoView({block: "start"});
+                }
             }
         }
     }
@@ -788,6 +798,10 @@ export class CategoryItem extends data.Component<CategoryItemProps, CategoryItem
 
     scrollElementIntoView(options: ScrollIntoViewOptions) {
         this.treeRowElement.scrollIntoView(options);
+    }
+
+    getBoundingClientRect() {
+        return this.treeRowElement.getBoundingClientRect();
     }
 
     handleClick(e: React.MouseEvent<any>) {
@@ -883,6 +897,13 @@ export class TreeRow extends data.Component<TreeRowProps, {}> {
 
     scrollIntoView(options: ScrollIntoViewOptions) {
         if (this.treeRow) this.treeRow.scrollIntoView(options);
+    }
+
+    getBoundingClientRect() {
+        if (this.treeRow) {
+            return this.treeRow.getBoundingClientRect();
+        }
+        return undefined;
     }
 
     getProperties() {


### PR DESCRIPTION
Fix a bug where if you use keyboard navigation to move halfway down the category list, then move back up whilst in the middle of the scroll area, an unexpected scroll into view occurs. See video:

https://github.com/user-attachments/assets/1a1edc02-3cc8-438d-b691-d7f967b98125

I'd like an easier / nicer way to get the toolbox parent to work out when to scroll into view, or just a better way to know when to scroll into view.