### PR TITLE
Enable workspace navigation after clicking ledmatrix LED

### DIFF
--- a/pxtblocks/fields/field_ledmatrix.ts
+++ b/pxtblocks/fields/field_ledmatrix.ts
@@ -352,6 +352,8 @@ export class FieldMatrix extends Blockly.Field implements FieldCustom {
             // Clear event listeners and selection used for keyboard navigation.
             this.removeKeyboardFocusHandlers();
             this.clearSelection();
+            // This enables keyboard navigation in the Blockly workspace if not focused already.
+            (this.sourceBlock_.workspace as Blockly.WorkspaceSvg).markFocused();
         }, false));
     }
 


### PR DESCRIPTION
Fixes a bug spotted by Kirsty. Focus is outside of the Blockly workspace, clicking an LED did not move focus at all, so you couldn't navigate via keyboard afterwards.

This does not impact the existing/old keyboard navigation plugin as it doesn't enable keyboard navigation when clicking on any blocks.