### PR TITLE
Simple css fix to carousel highlight

### DIFF
--- a/theme/home.less
+++ b/theme/home.less
@@ -102,6 +102,11 @@
                 border-color: @heroBannerDotOutlineAtiveColor;
                 background-color: transparent;
             }
+
+            &:focus {
+                box-shadow: 0 0 0 calc(@homeHeaderBorderSize + 1px) @homeHeaderSelectedBorderColor;
+                outline: 1px ridge black;
+            }
         }
 
         .gradient-overlay {

--- a/theme/home.less
+++ b/theme/home.less
@@ -103,7 +103,7 @@
                 background-color: transparent;
             }
 
-            &:focus {
+            &:focus-visible {
                 box-shadow: 0 0 0 calc(@homeHeaderBorderSize + 1px) @homeHeaderSelectedBorderColor;
                 outline: 1px ridge black;
             }


### PR DESCRIPTION
![focus-carousel](https://github.com/user-attachments/assets/f73c79b1-9048-43af-b316-02b83415a28e)

This is problematic as it has inconsistent tab-arrow behaviour but it's only really highlighting the existing problems with interaction as arrow highlighting is not focus (see gif). As time is of the essence this is the simplest solution to give a bit more visible clarity.

Any solution that focuses on arrow key navigation will need additional aria tagging to make it clear what is being selected, as well as figuring out what javascript behaviours are needed. It would be better IMO to convert the whole button array to radio elements, but this is a bigger task.

In the meantime, at least you can see where your tab cursor went.