### PR TITLE
More focus borders

### DIFF
--- a/theme/common.less
+++ b/theme/common.less
@@ -223,12 +223,24 @@ pre {
     transition-timing-function: linear;
 }
 
+.editor-sidebar .simtoolbar .ui.button:focus {
+    border: 2px solid transparent;
+    outline: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
+}
+
 #downloadArea {
     margin: unset;
 
     > div {
         margin: 0;
     }
+}
+
+#downloadArea .button:focus,
+#editortools .button:focus
+{
+    border: 2px solid white;
+    outline: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
 }
 
 #editorToolbarArea {
@@ -655,6 +667,10 @@ div.simframe > iframe {
     left: -21px;
     top: calc(~'40% - 2.4rem');
     height: calc(~'20% + 0.8rem');
+    &:focus {
+        border: 2px solid transparent;
+        outline: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
+    }
 }
 
 .collapsedEditorTools #computertogglesim,

--- a/theme/home.less
+++ b/theme/home.less
@@ -102,6 +102,11 @@
                 border-color: @heroBannerDotOutlineAtiveColor;
                 background-color: transparent;
             }
+
+            &:focus {
+                box-shadow: 0 0 0 calc(@homeHeaderBorderSize + 1px) @homeHeaderSelectedBorderColor;
+                outline: 1px ridge black;
+            }
         }
 
         .gradient-overlay {

--- a/theme/home.less
+++ b/theme/home.less
@@ -91,6 +91,10 @@
 
         .action {
             margin: 1rem 0;
+            a:focus, button:focus {
+                box-shadow: 0 0 0 calc(@homeHeaderBorderSize + 1px) @homeHeaderSelectedBorderColor;
+                outline: 1px ridge black;
+            }
         }
 
         .dots button {
@@ -160,6 +164,8 @@
                     transition: border-color 400ms ease;
                     &:hover, &:focus {
                         border-color: @primaryColor;
+                        border: 2px solid white;
+                        outline: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
                     }
                 }
             }
@@ -182,6 +188,10 @@
     .import-dialog-btn {
         position: relative;
         z-index: 1; /* Move up so it's above the carousel container that has an offset margin */
+        &:focus {
+            border: 2px solid white;
+            outline: @homeCardBorderSize solid @homeCardFocusBorderColor !important;
+        }
     }
     /* Footer, Privary, Terms of Use */
     .homefooter {


### PR DESCRIPTION
Tried to reuse styles from either the top menu focus (on darker backgrounds) or the outline from project items (on lighter backgrounds)
![focus-editor](https://github.com/user-attachments/assets/90e86758-43f5-4ff6-8b51-60ac08de3708)
![focus-projects](https://github.com/user-attachments/assets/caf192f7-68dc-494b-925f-32e9836053cd)
