### PR TITLE
Launch the blockly keyboard controls help from the MakeCode menu

### DIFF
--- a/localtypings/blockly-keyboard-experiment.d.ts
+++ b/localtypings/blockly-keyboard-experiment.d.ts
@@ -14,5 +14,6 @@ declare module "@blockly/keyboard-experiment" {
    focusFlyout(): void;
    onExternalToolboxFocus(): void;
    onExternalToolboxBlur(): void;
+   toggleShortcutDialog(): void;
   }
 }

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -1048,6 +1048,7 @@ declare namespace pxt.editor {
         showKeymap(show: boolean): void;
         toggleKeymap(): void;
         signOutGithub(): void;
+        toggleShortcutDialog(): void;
 
         showReportAbuse(): void;
         showLanguagePicker(): void;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -1412,6 +1412,10 @@ export class ProjectView
             sd.expand();
         }
     }
+    
+    toggleShortcutDialog() {
+        this.blocksEditor?.toggleShortcutDialog();
+    }
 
     setTutorialInstructionsExpanded(value: boolean): void {
         const tutorialOptions = this.state.tutorialOptions;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -290,6 +290,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         (block.getField(asset.meta.temporaryInfo.fieldName) as pxtblockly.FieldAssetEditor<any, any>).updateAsset(asset);
     }
 
+    toggleShortcutDialog() {
+        this.keyboardNavigation.toggleShortcutDialog();
+    }
+
     private saveBlockly(): string {
         // make sure we don't return an empty document before we get started
         // otherwise it may get saved and we're in trouble

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -45,6 +45,12 @@ function startTour(parent: IProjectView) {
     parent.showOnboarding();
 }
 
+function openKeyboardNavFn(parent: IProjectView) {
+    return function() {
+        parent.toggleShortcutDialog();
+    }
+}
+
 function renderDocItems(parent: IProjectView, elements: pxt.DocMenuEntry[], cls: string = "") {
     return elements.map(m =>
         m.tutorial ? <DocsMenuItem key={"docsmenututorial" + m.path} role="menuitem" ariaLabel={pxt.Util.rlf(m.name)} text={pxt.Util.rlf(m.name)} className={"ui " + cls} parent={parent} path={m.path} onItemClick={openTutorial} />
@@ -76,6 +82,13 @@ export class DocsMenu extends data.PureComponent<DocsMenuProps, {}> {
         const targetTheme = pxt.appTarget.appTheme;
         return <sui.DropdownMenu role="menuitem" icon="help circle large"
             className="item mobile hide help-dropdown-menuitem" textClass={"landscape only"} title={lf("Help")} >
+            <DocsMenuItem key="keyboardnav" 
+                role="menuitem" 
+                ariaLabel={pxt.Util.rlf("Keyboard Navigation")} 
+                text={pxt.Util.rlf("Keyboard Navigation")} 
+                className="ui" parent={parent} 
+                onItemClick={openKeyboardNavFn(parent)} 
+                path="/keyboardnav" />
             {targetTheme.tours?.editor && getTourItem(parent)}
             {renderDocItems(parent, targetTheme.docMenu)}
             {getDocsLanguageItem(this.props.editor, parent)}


### PR DESCRIPTION
<img width="279" alt="image" src="https://github.com/user-attachments/assets/d930ceb4-024d-40c5-a822-8e037cec2335" />

Apologies for all the prop drilling.