### PR TITLE
Fix for over eager initial workspace focus

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2788,7 +2788,7 @@ export class ProjectView
         this.stopSimulator(true); // don't keep simulator around
         this.showKeymap(false); // close keymap if open
         cmds.disconnectAsync(); // turn off any kind of logging
-        if (this.editor) this.editor.unloadFileAsync();
+        if (this.editor) this.editor.unloadFileAsync(home);
         this.extensions.unload();
         this.editorFile = undefined;
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -54,7 +54,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     loadingXml: boolean;
     loadingXmlPromise: Promise<any>;
     compilationResult: pxtblockly.BlockCompilationResult;
-    isFirstLoad = true;
+    shouldFocusWorkspace = false;
     functionsDialog: CreateFunctionDialog = null;
 
     showCategories: boolean = true;
@@ -169,8 +169,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             pxt.Util.toArray(document.querySelectorAll(classes)).forEach((el: HTMLElement) => el.style.display = 'none');
             if (this.editor) Blockly.hideChaff();
             if (this.toolbox) this.toolbox.clearExpandedItem();
-            // Update isFirstLoad here to handle when the app switches to JavaScript or Python immediately.
-            this.isFirstLoad = false;
         }
     }
 
@@ -238,7 +236,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
                     this.resize();
                     Blockly.svgResize(this.editor);
-                    this.isFirstLoad = false;
+                    this.shouldFocusWorkspace = true;
                 }).finally(() => {
                     try {
                         // It's possible Blockly reloads and the loading dimmer is no longer a child of the editorDiv
@@ -331,7 +329,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             this.typeScriptSaveable = true;
 
-            if (!this.isFirstLoad) {
+            if (this.shouldFocusWorkspace) {
                 this.focusWorkspace();
             }
         } catch (e) {
@@ -1102,9 +1100,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             })
     }
 
-    unloadFileAsync(): Promise<void> {
+    unloadFileAsync(unloadToHome?: boolean): Promise<void> {
         this.delayLoadXml = undefined;
         if (this.toolbox) this.toolbox.clearSearch();
+        if (unloadToHome) this.shouldFocusWorkspace = false;
         return Promise.resolve();
     }
 

--- a/webapp/src/srceditor.tsx
+++ b/webapp/src/srceditor.tsx
@@ -74,7 +74,7 @@ export class Editor implements IEditor {
     snapshotState(): any {
         return null
     }
-    unloadFileAsync(): Promise<void> { return Promise.resolve() }
+    unloadFileAsync(unloadToHome?: boolean): Promise<void> { return Promise.resolve() }
 
     isIncomplete() {
         return false


### PR DESCRIPTION
Don't focus the Blocks workspace when navigating to the editor from the homepage

Works better with https://github.com/microbit-matt-hillsdon/blockly-keyboard-experimentation/pull/3