### PR TITLE
Download dialog close button

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -948,7 +948,7 @@ declare namespace pxt.editor {
         saveAndCompile(): void;
         updateHeaderName(name: string): void;
         updateHeaderNameAsync(name: string): Promise<void>;
-        compile(): void;
+        compile(saveOnly?: boolean): void;
 
         setFile(fn: IFile, line?: number): void;
         setSideFile(fn: IFile, line?: number): void;
@@ -1083,7 +1083,7 @@ declare namespace pxt.editor {
         showPackageDialog(query?: string): void;
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
-        pairAsync(): Promise<boolean>;
+        pairUiAsync(): Promise<pxt.commands.WebUSBPairResult>;
 
         createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -258,7 +258,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                     .then(() => projectView.printCode());
                             }
                             case "pair": {
-                                return projectView.pairAsync().then(() => {});
+                                return projectView.pairUiAsync().then(() => {});
                             }
                             case "info": {
                                 return Promise.resolve()

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -3,6 +3,7 @@ namespace pxt.commands {
         Failed = 0,
         Success = 1,
         UserRejected = 2,
+        DownloadOnly = 3,
     }
 
     export interface RecompileOptions {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3223,8 +3223,8 @@ export class ProjectView
             );
     }
 
-    pairAsync(): Promise<boolean> {
-        return cmds.pairAsync();
+    pairUiAsync(): Promise<pxt.commands.WebUSBPairResult> {
+        return cmds.pairUiAsync();
     }
 
     ///////////////////////////////////////////////////////////
@@ -3266,7 +3266,7 @@ export class ProjectView
         const variants = pxt.getHwVariants()
         if (variants.length == 0)
             return false
-        let pairAsync = () => cmds.pairAsync()
+        let pairAsync = () => cmds.pairUiAsync()
             .then(() => {
                 this.checkForHwVariant()
             }, err => {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -241,7 +241,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     pair() {
         pxt.tickEvent("menu.pair");
-        this.props.parent.pairAsync();
+        this.props.parent.pairUiAsync();
     }
 
     pairBluetooth() {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -13,7 +13,7 @@ import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 import { TimeMachine } from "./timeMachine";
 import { fireClickOnEnter } from "./util";
-import { pairAsync } from "./cmds";
+import { pairUiAsync } from "./cmds";
 import { invalidate } from "./data";
 
 import IProjectView = pxt.editor.IProjectView;
@@ -752,8 +752,8 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean, redeploy?:
 
     const onPairClicked = async () => {
         core.hideDialog();
-        const successfulPairing = await pairAsync(true);
-        if (redeploy && successfulPairing)
+        const pairingStatus = await pairUiAsync();
+        if (redeploy && pairingStatus === pxt.commands.WebUSBPairResult.Success)
             await redeploy();
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -48,10 +48,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         this.props.parent.updateHeaderName(name);
     }
 
-    compile(view?: string) {
+    compile(view?: string, saveOnly?: boolean) {
         this.setState({ compileState: "compiling" });
         pxt.tickEvent("editortools.download", { view: view, collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        this.props.parent.compile();
+        this.props.parent.compile(saveOnly);
     }
 
     saveFile(view?: string) {
@@ -187,13 +187,18 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        let pairResult = pxt.commands.WebUSBPairResult.Success;
         if (this.shouldShowPairingDialogOnDownload()
             && !pxt.packetio.isConnected()
             && !pxt.packetio.isConnecting()
         ) {
-            await cmds.pairAsync(true);
+            pairResult = await cmds.pairUiAsync(true);
         }
-        this.compile();
+        if (pairResult === pxt.commands.WebUSBPairResult.Success) {
+            this.compile(undefined, false);
+        } else if (pairResult === pxt.commands.WebUSBPairResult.DownloadOnly) {
+            this.compile(undefined, true);
+        }
     }
 
     protected onFileDownloadClick = async () => {
@@ -205,7 +210,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onPairClick = () => {
         pxt.tickEvent("editortools.pair", undefined, { interactiveConsent: true });
-        this.props.parent.pairAsync();
+        this.props.parent.pairUiAsync();
     }
 
     protected onCannotPairClick = async () => {

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -74,8 +74,10 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         if (connected) {
             // plugged in underneath previous dialog, continue;
             core.hideDialog();
-        } else if (!webUsbInstrDialogRes) {
+        } else if (webUsbInstrDialogRes === ShowPairStepResult.Rejected) {
             return notPairedResult();
+        } else if (webUsbInstrDialogRes === ShowPairStepResult.DownloadOnly) {
+            return pxt.commands.WebUSBPairResult.DownloadOnly;
         } else {
             let errMessage: any;
             try {
@@ -158,7 +160,6 @@ function showConnectDeviceDialogAsync(confirmAsync: ConfirmAsync) {
     );
 
     return showPairStepAsync({
-        hideClose: true,
         confirmAsync,
         jsxd,
         buttonLabel: lf("Next"),
@@ -304,6 +305,12 @@ interface PairStepOptions {
     doNotHideOnAgree?: boolean;
 }
 
+enum ShowPairStepResult {
+    Rejected,
+    Accepted,
+    DownloadOnly
+}
+
 async function showPairStepAsync({
     confirmAsync,
     jsxd,
@@ -317,7 +324,7 @@ async function showPairStepAsync({
     hideClose,
     doNotHideOnAgree,
 }: PairStepOptions) {
-    let tryAgain = false;
+    let tryAgain = ShowPairStepResult.Rejected;
 
     /**
      * The deferred below is only used when doNotHideOnAgree is set
@@ -335,7 +342,7 @@ async function showPairStepAsync({
             labelPosition: "left",
             onclick: () => {
                 pxt.tickEvent(tick);
-                tryAgain = true;
+                tryAgain = ShowPairStepResult.Accepted;
                 if (doNotHideOnAgree) {
                     deferred();
                 }
@@ -353,7 +360,7 @@ async function showPairStepAsync({
             onclick: () => {
                 pxt.tickEvent("downloaddialog.button.webusb.preferdownload");
                 userPrefersDownloadFlag = true;
-                tryAgain = false;
+                tryAgain = ShowPairStepResult.DownloadOnly;
             },
         });
     }

--- a/webapp/src/webusb.tsx
+++ b/webapp/src/webusb.tsx
@@ -123,9 +123,10 @@ export async function webUsbPairThemedDialogAsync(pairAsync: () => Promise<boole
         await showConnectionSuccessAsync(confirmAsync, implicitlyCalled);
     }
     else {
-        const tryAgain = await showConnectionFailureAsync(confirmAsync, implicitlyCalled, lastPairingError);
+        const userResponse = await showConnectionFailureAsync(confirmAsync, implicitlyCalled, lastPairingError);
 
-        if (tryAgain) return webUsbPairThemedDialogAsync(pairAsync, confirmAsync, implicitlyCalled);
+        if (userResponse === ShowPairStepResult.Accepted) return webUsbPairThemedDialogAsync(pairAsync, confirmAsync, implicitlyCalled);
+        else if (userResponse === ShowPairStepResult.DownloadOnly) return pxt.commands.WebUSBPairResult.DownloadOnly;
     }
 
     if (paired) {
@@ -323,8 +324,8 @@ async function showPairStepAsync({
     showDownloadAsFileButton,
     hideClose,
     doNotHideOnAgree,
-}: PairStepOptions) {
-    let tryAgain = ShowPairStepResult.Rejected;
+}: PairStepOptions): Promise<ShowPairStepResult> {
+    let userResponse = ShowPairStepResult.Rejected;
 
     /**
      * The deferred below is only used when doNotHideOnAgree is set
@@ -342,7 +343,7 @@ async function showPairStepAsync({
             labelPosition: "left",
             onclick: () => {
                 pxt.tickEvent(tick);
-                tryAgain = ShowPairStepResult.Accepted;
+                userResponse = ShowPairStepResult.Accepted;
                 if (doNotHideOnAgree) {
                     deferred();
                 }
@@ -360,7 +361,7 @@ async function showPairStepAsync({
             onclick: () => {
                 pxt.tickEvent("downloaddialog.button.webusb.preferdownload");
                 userPrefersDownloadFlag = true;
-                tryAgain = ShowPairStepResult.DownloadOnly;
+                userResponse = ShowPairStepResult.DownloadOnly;
             },
         });
     }
@@ -386,7 +387,7 @@ async function showPairStepAsync({
         await dialog;
     }
 
-    return tryAgain;
+    return userResponse;
 }
 
 export function webUsbPairLegacyDialogAsync(pairAsync: () => Promise<boolean>, confirmAsync: ConfirmAsync): Promise<number> {


### PR DESCRIPTION
<img width="526" alt="image" src="https://github.com/user-attachments/assets/a9da0bfd-d426-45dd-8561-d5147f8b3cf3" />

As part of this work, clarified the difference in behaviour between the different state transitions in the download flow. Particularly, in order to cancel the flow we needed to distinguish between

* User cancelled
* Failure
* Download-only requested
* Success

As a minor detail, there were two sets of functions called `pairAsync`, one was hardware-related and one was UI-related. This was impeding my understanding, so the latter has been renamed `pairUiAsync`.

### API changes and potential breakage

I have modified a few functions in the `pxt` namespace

* `pxt.editor.compile` - added an optional flag, should not break existing consumers
* `pairAsync` - renamed to `pairUiAsync`. Changed the return type from `boolean` to `WebUSBPairResult` so that the consumer in `EditorToolbar.onDownloadButtonClick` can correctly manage the ensuing compile flow.
* `pxt.commands.WebUSBPairResult` - extended to include a `DownloadOnly` state that becomes necessary to know when breaking out of the multi-dialog flow

Demo: https://download-dialog-close-button.review-pxt.pages.dev/#editor