### PR TITLE
Prevent default for shortcuts in simulator

### DIFF
--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -10,11 +10,14 @@ namespace pxsim.accessibility {
 
     export function postKeyboardEvent() {
         document.addEventListener("keydown", (e) => {
-            // TODO: origin
-            window.parent.postMessage(
-              { key: e.key, metaKey: e.metaKey, ctrlKey: e.ctrlKey },
-              "*"
-            );
+            if (["e", "/", "b", "d"].includes(e.key) && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault()
+                // TODO: origin
+                window.parent.postMessage(
+                    { key: e.key, metaKey: e.metaKey, ctrlKey: e.ctrlKey },
+                    "*"
+                );
+            }
         });
     }
 

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -13,7 +13,7 @@ namespace pxsim.accessibility {
     type SimulatorShortcutMessage = pxsim.SimulatorToggleShortcutDocMessage
         | pxsim.SimulatorFocusWorkspaceMessage
         | pxsim.SimulatorFocusSimulatorMessage
-        | pxsim.SimulatorDownloadMessage
+        | pxsim.SimulatorWebUSBDownloadMessage
     type EditorCommand = SimulatorShortcutMessage["type"]
     const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
         const meta  = e.metaKey || e.ctrlKey;
@@ -28,7 +28,7 @@ namespace pxsim.accessibility {
             return "focusSimulator"
         } else if (e.key === "d" && meta) {
             e.preventDefault();
-            return "download"
+            return "webUSBDownload"
         }
         return null
     }

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -10,11 +10,7 @@ namespace pxsim.accessibility {
 
     // Matching in initAccessibilityBlocks shortcuts in blocks.tsx so that
     // the keyboard shortcuts are handled the same way in the simulator iframe.
-    type SimulatorShortcutMessage = pxsim.SimulatorToggleShortcutDocMessage
-        | pxsim.SimulatorFocusWorkspaceMessage
-        | pxsim.SimulatorFocusSimulatorMessage
-        | pxsim.SimulatorWebUSBDownloadMessage
-    type EditorCommand = SimulatorShortcutMessage["type"]
+    type EditorCommand = pxsim.SimulatorActionMessage["type"]
     const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
         const meta  = e.metaKey || e.ctrlKey;
         if (e.key === "/" && meta) {

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -8,8 +8,13 @@ namespace pxsim.accessibility {
         elem.setAttribute("tabindex", "0");
     }
 
-    // Matching initAccessibilityBlocks shortcuts in blocks.tsx.
-    type EditorCommand = "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "download"
+    // Matching in initAccessibilityBlocks shortcuts in blocks.tsx so that
+    // the keyboard shortcuts are handled the same way in the simulator iframe.
+    type SimulatorShortcutMessage = pxsim.SimulatorToggleShortcutDocMessage
+        | pxsim.SimulatorFocusWorkspaceMessage
+        | pxsim.SimulatorFocusSimulatorMessage
+        | pxsim.SimulatorDownloadMessage
+    type EditorCommand = SimulatorShortcutMessage["type"]
     const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
         const meta  = e.metaKey || e.ctrlKey;
         if (e.key === "/" && meta) {
@@ -32,9 +37,7 @@ namespace pxsim.accessibility {
         document.addEventListener("keydown", (e) => {
             const command = getEditorCommand(e)
             if (command) {
-                e.preventDefault()
-                // TODO: origin
-                window.parent.postMessage(command, "*");
+                Runtime.postMessage({ type: command })
             }
         });
     }

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -10,8 +10,7 @@ namespace pxsim.accessibility {
 
     // Matching in initAccessibilityBlocks shortcuts in blocks.tsx so that
     // the keyboard shortcuts are handled the same way in the simulator iframe.
-    type EditorCommand = pxsim.SimulatorActionMessage["type"]
-    const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
+    const getKeyboardShortcutEditorAction = (e: KeyboardEvent): pxsim.SimulatorActionMessage["type"] | null => {
         const meta  = e.metaKey || e.ctrlKey;
         if (e.key === "/" && meta) {
             e.preventDefault();
@@ -31,9 +30,9 @@ namespace pxsim.accessibility {
 
     export function postKeyboardEvent() {
         document.addEventListener("keydown", (e) => {
-            const command = getEditorCommand(e)
-            if (command) {
-                Runtime.postMessage({ type: command })
+            const action = getKeyboardShortcutEditorAction(e)
+            if (action) {
+                Runtime.postMessage({ type: action })
             }
         });
     }

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -8,9 +8,7 @@ namespace pxsim.accessibility {
         elem.setAttribute("tabindex", "0");
     }
 
-    // Matching in initAccessibilityBlocks shortcuts in blocks.tsx so that
-    // the keyboard shortcuts are handled the same way in the simulator iframe.
-    const getKeyboardShortcutEditorAction = (e: KeyboardEvent): pxsim.SimulatorActionMessage["type"] | null => {
+    export function getKeyboardShortcutEditorAction(e: KeyboardEvent): pxsim.SimulatorActionMessage["type"] | null {
         const meta  = e.metaKey || e.ctrlKey;
         if (e.key === "/" && meta) {
             e.preventDefault();

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -8,15 +8,33 @@ namespace pxsim.accessibility {
         elem.setAttribute("tabindex", "0");
     }
 
+    // Matching initAccessibilityBlocks shortcuts in blocks.tsx.
+    type EditorCommand = "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "download"
+    const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
+        const meta  = e.metaKey || e.ctrlKey;
+        if (e.key === "/" && meta) {
+            e.preventDefault();
+            return "toggleShortcutDoc"
+        } else if (e.key === "e" && meta) {
+            e.preventDefault();
+            return "focusWorkspace"
+        } else if (e.key === "b" && meta) {
+            e.preventDefault();
+            return "focusSimulator"
+        } else if (e.key === "d" && meta) {
+            e.preventDefault();
+            return "download"
+        }
+        return null
+    }
+
     export function postKeyboardEvent() {
         document.addEventListener("keydown", (e) => {
-            if (["e", "/", "b", "d"].includes(e.key) && (e.metaKey || e.ctrlKey)) {
+            const command = getEditorCommand(e)
+            if (command) {
                 e.preventDefault()
                 // TODO: origin
-                window.parent.postMessage(
-                    { key: e.key, metaKey: e.metaKey, ctrlKey: e.ctrlKey },
-                    "*"
-                );
+                window.parent.postMessage(command, "*");
             }
         });
     }

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -75,20 +75,8 @@ namespace pxsim {
         url: string;
     }
 
-    export interface SimulatorToggleShortcutDocMessage extends SimulatorMessage {
-        type: "toggleShortcutDoc";
-    }
-
-    export interface SimulatorFocusWorkspaceMessage extends SimulatorMessage {
-        type: "focusWorkspace";
-    }
-
-    export interface SimulatorFocusSimulatorMessage extends SimulatorMessage {
-        type: "focusSimulator";
-    }
-
-    export interface SimulatorWebUSBDownloadMessage extends SimulatorMessage {
-        type: "webUSBDownload";
+    export interface SimulatorActionMessage extends SimulatorMessage {
+        type: "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "webUSBDownload";
     }
 
     export interface SimulatorStateMessage extends SimulatorMessage {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -75,6 +75,22 @@ namespace pxsim {
         url: string;
     }
 
+    export interface SimulatorToggleShortcutDocMessage extends SimulatorMessage {
+        type: "toggleShortcutDoc";
+    }
+
+    export interface SimulatorFocusWorkspaceMessage extends SimulatorMessage {
+        type: "focusWorkspace";
+    }
+
+    export interface SimulatorFocusSimulatorMessage extends SimulatorMessage {
+        type: "focusSimulator";
+    }
+
+    export interface SimulatorDownloadMessage extends SimulatorMessage {
+        type: "download";
+    }
+
     export interface SimulatorStateMessage extends SimulatorMessage {
         type: "status";
         frameid?: string;

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -87,8 +87,8 @@ namespace pxsim {
         type: "focusSimulator";
     }
 
-    export interface SimulatorDownloadMessage extends SimulatorMessage {
-        type: "download";
+    export interface SimulatorWebUSBDownloadMessage extends SimulatorMessage {
+        type: "webUSBDownload";
     }
 
     export interface SimulatorStateMessage extends SimulatorMessage {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -598,7 +598,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     return "focusSimulator"
                 } else if (e.key === "d" && meta) {
                     e.preventDefault();
-                    return "download"
+                    return "webUSBDownload"
                 }
                 return null
             }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -578,7 +578,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 ]
             });
 
-            type EditorCommand = "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "download"
+            // Duplicated in simulator pxtsim accessibility.ts so that the
+            // the keyboard shortcuts are handled the same way in the simulator iframe.
+            type SimulatorShortcutMessage = pxsim.SimulatorToggleShortcutDocMessage
+                | pxsim.SimulatorFocusWorkspaceMessage
+                | pxsim.SimulatorFocusSimulatorMessage
+                | pxsim.SimulatorDownloadMessage
+            type EditorCommand = SimulatorShortcutMessage["type"]
             const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
                 const meta  = e.metaKey || e.ctrlKey;
                 if (e.key === "/" && meta) {
@@ -637,13 +643,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 // Simulator deployed origin.
                 "https://trg-microbit.userpxt.io"
             ]
-            window.addEventListener("message", (e) => {
+            window.addEventListener("message", (e: MessageEvent) => {
                 // Listen to simulator iframe keydown post messages.
                 if (simulatorOrigins.includes(e.origin)) {
-                    triggerEditorCommand(e.data)
+                    const msg = e.data as SimulatorShortcutMessage
+                    triggerEditorCommand(msg.type)
                 }
             }, false)
-            document.addEventListener("keydown", (e) => {
+            document.addEventListener("keydown", (e: KeyboardEvent) => {
                 const command = getEditorCommand(e)
                 triggerEditorCommand(command)
             });

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -580,8 +580,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             // Duplicated in simulator pxtsim accessibility.ts so that the
             // the keyboard shortcuts are handled the same way in the simulator iframe.
-            type EditorCommand = pxsim.SimulatorActionMessage["type"]
-            const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
+            const getKeyboardShortcutEditorAction = (e: KeyboardEvent): pxsim.SimulatorActionMessage["type"] | null => {
                 const meta  = e.metaKey || e.ctrlKey;
                 if (e.key === "/" && meta) {
                     e.preventDefault();
@@ -599,8 +598,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 return null
             }
 
-            const triggerEditorCommand = (command: EditorCommand) => {
-                switch (command) {
+            const triggerEditorAction = (action: pxsim.SimulatorActionMessage["type"]) => {
+                switch (action) {
                     case "toggleShortcutDoc": {
                         this.parent.toggleBuiltInSideDoc("keyboardNav", false);
                         return
@@ -642,12 +641,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             window.addEventListener("message", (e: MessageEvent<pxsim.SimulatorActionMessage>) => {
                 // Listen to simulator iframe keydown post messages.
                 if (simulatorOrigins.includes(e.origin)) {
-                    triggerEditorCommand(e.data.type)
+                    triggerEditorAction(e.data.type)
                 }
             }, false)
             document.addEventListener("keydown", (e: KeyboardEvent) => {
-                const command = getEditorCommand(e)
-                triggerEditorCommand(command)
+                const action = getKeyboardShortcutEditorAction(e)
+                triggerEditorAction(action)
             });
         }
     }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -580,11 +580,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             // Duplicated in simulator pxtsim accessibility.ts so that the
             // the keyboard shortcuts are handled the same way in the simulator iframe.
-            type SimulatorShortcutMessage = pxsim.SimulatorToggleShortcutDocMessage
-                | pxsim.SimulatorFocusWorkspaceMessage
-                | pxsim.SimulatorFocusSimulatorMessage
-                | pxsim.SimulatorWebUSBDownloadMessage
-            type EditorCommand = SimulatorShortcutMessage["type"]
+            type EditorCommand = pxsim.SimulatorActionMessage["type"]
             const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
                 const meta  = e.metaKey || e.ctrlKey;
                 if (e.key === "/" && meta) {
@@ -643,11 +639,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 // Simulator deployed origin.
                 "https://trg-microbit.userpxt.io"
             ]
-            window.addEventListener("message", (e: MessageEvent) => {
+            window.addEventListener("message", (e: MessageEvent<pxsim.SimulatorActionMessage>) => {
                 // Listen to simulator iframe keydown post messages.
                 if (simulatorOrigins.includes(e.origin)) {
-                    const msg = e.data as SimulatorShortcutMessage
-                    triggerEditorCommand(msg.type)
+                    triggerEditorCommand(e.data.type)
                 }
             }, false)
             document.addEventListener("keydown", (e: KeyboardEvent) => {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -578,26 +578,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 ]
             });
 
-            // Duplicated in simulator pxtsim accessibility.ts so that the
-            // the keyboard shortcuts are handled the same way in the simulator iframe.
-            const getKeyboardShortcutEditorAction = (e: KeyboardEvent): pxsim.SimulatorActionMessage["type"] | null => {
-                const meta  = e.metaKey || e.ctrlKey;
-                if (e.key === "/" && meta) {
-                    e.preventDefault();
-                    return "toggleShortcutDoc"
-                } else if (e.key === "e" && meta) {
-                    e.preventDefault();
-                    return "focusWorkspace"
-                } else if (e.key === "b" && meta) {
-                    e.preventDefault();
-                    return "focusSimulator"
-                } else if (e.key === "d" && meta) {
-                    e.preventDefault();
-                    return "webUSBDownload"
-                }
-                return null
-            }
-
             const triggerEditorAction = (action: pxsim.SimulatorActionMessage["type"]) => {
                 switch (action) {
                     case "toggleShortcutDoc": {
@@ -645,7 +625,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
             }, false)
             document.addEventListener("keydown", (e: KeyboardEvent) => {
-                const action = getKeyboardShortcutEditorAction(e)
+                const action = pxsim.accessibility.getKeyboardShortcutEditorAction(e)
                 triggerEditorAction(action)
             });
         }

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -583,7 +583,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             type SimulatorShortcutMessage = pxsim.SimulatorToggleShortcutDocMessage
                 | pxsim.SimulatorFocusWorkspaceMessage
                 | pxsim.SimulatorFocusSimulatorMessage
-                | pxsim.SimulatorDownloadMessage
+                | pxsim.SimulatorWebUSBDownloadMessage
             type EditorCommand = SimulatorShortcutMessage["type"]
             const getEditorCommand = (e: KeyboardEvent): EditorCommand | null => {
                 const meta  = e.metaKey || e.ctrlKey;
@@ -618,7 +618,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         (document.querySelector("#boardview") as HTMLElement).focus();
                         return
                     }
-                    case "download": {
+                    case "webUSBDownload": {
                         (async () => {
                             // TODO: refactor and share with editortoolbar.tsx
                             const shouldShowPairingDialogOnDownload = pxt.appTarget.appTheme.preferWebUSBDownload


### PR DESCRIPTION
Hacky fix for Ctrl+E in simulator opens browser search bar issue
