### PR TITLE
Input combo keyboard improvements

### DIFF
--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -30,6 +30,7 @@ export interface ButtonProps extends ButtonViewProps {
     onClick: () => void;
     onRightClick?: () => void;
     onBlur?: () => void;
+    onFocus?: () => void;
     onKeydown?: (e: React.KeyboardEvent) => void;
 }
 
@@ -53,6 +54,7 @@ export const Button = (props: ButtonProps) => {
         onRightClick,
         onKeydown,
         onBlur,
+        onFocus,
         buttonRef,
         title,
         label,
@@ -105,6 +107,7 @@ export const Button = (props: ButtonProps) => {
             onContextMenu={rightClickHandler}
             onKeyDown={onKeydown || fireClickOnEnter}
             onBlur={onBlur}
+            onFocus={onFocus}
             role={role || "button"}
             tabIndex={tabIndex || (disabled ? -1 : 0)}
             disabled={hardDisabled}

--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -27,7 +27,7 @@ export interface ButtonViewProps extends ContainerProps {
 
 
 export interface ButtonProps extends ButtonViewProps {
-    onClick: () => void;
+    onClick: (evt?: React.MouseEvent<Element>) => void;
     onRightClick?: () => void;
     onBlur?: () => void;
     onFocus?: () => void;
@@ -82,7 +82,7 @@ export const Button = (props: ButtonProps) => {
     );
 
     let clickHandler = (ev: React.MouseEvent) => {
-        if (onClick) onClick();
+        if (onClick) onClick(ev);
         if (href) window.open(href, target || "_blank", "noopener,noreferrer")
         ev.stopPropagation();
         ev.preventDefault();

--- a/react-common/components/controls/Button.tsx
+++ b/react-common/components/controls/Button.tsx
@@ -27,7 +27,7 @@ export interface ButtonViewProps extends ContainerProps {
 
 
 export interface ButtonProps extends ButtonViewProps {
-    onClick: (evt?: React.MouseEvent<Element>) => void;
+    onClick: () => void;
     onRightClick?: () => void;
     onBlur?: () => void;
     onFocus?: () => void;
@@ -82,7 +82,7 @@ export const Button = (props: ButtonProps) => {
     );
 
     let clickHandler = (ev: React.MouseEvent) => {
-        if (onClick) onClick(ev);
+        if (onClick) onClick();
         if (href) window.open(href, target || "_blank", "noopener,noreferrer")
         ev.stopPropagation();
         ev.preventDefault();

--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -109,6 +109,15 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                 const svg = screenToSVGCoord(ref.ownerSVGElement, coord);
                 throttledSetDragValue(index, svgCoordToValue(svg));
             };
+
+            ref.onkeydown = ev => {
+                const step = (max - min) / 100;
+                if (ev.code === "ArrowDown") {
+                    onPointChange(index, Math.max(min, points[index] - step));
+                } else if (ev.code === "ArrowUp") {
+                    onPointChange(index, Math.min(max, points[index] + step));
+                } 
+            }
         });
     }, [dragIndex, onPointChange])
 
@@ -201,7 +210,7 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                             height={height}
                             fill="white"
                             opacity={0}
-
+                            tabIndex={0}
                             />
                     </g>
             })}

--- a/react-common/components/controls/Dropdown.tsx
+++ b/react-common/components/controls/Dropdown.tsx
@@ -125,12 +125,10 @@ export const Dropdown = (props: DropdownProps) => {
                                     {...item}
                                     buttonRef={ref => focusableItems.current[item.id] = ref}
                                     className={classList("common-dropdown-item", item.className)}
-                                    onClick={(e) => {
+                                    onClick={() => {
                                         setExpanded(false);
                                         onItemSelected(item.id);
                                         dropdownButton.current?.focus();
-                                        e.stopPropagation();
-                                        e.preventDefault();
                                     }}
                                     ariaSelected={item.id === selectedId}
                                     role="option"/>

--- a/react-common/components/controls/FocusTrap/FocusTrap.tsx
+++ b/react-common/components/controls/FocusTrap/FocusTrap.tsx
@@ -33,7 +33,7 @@ const FocusTrapInner = (props: FocusTrapProps) => {
         dontRestoreFocus
     } = props;
 
-    let container: HTMLDivElement;
+    const container = React.useRef<HTMLDivElement>();
     const previouslyFocused = React.useRef<Element>(document.activeElement);
     const [stoleFocus, setStoleFocus] = React.useState(false);
 
@@ -49,15 +49,15 @@ const FocusTrapInner = (props: FocusTrapProps) => {
 
     const getElements = React.useCallback(() => {
         let all = nodeListToArray(
-            includeOutsideTabOrder ? container.querySelectorAll(`[tabindex]`) :
-            container.querySelectorAll(`[tabindex]:not([tabindex="-1"])`)
+            includeOutsideTabOrder ? container.current.querySelectorAll(`[tabindex]`) :
+            container.current.querySelectorAll(`[tabindex]:not([tabindex="-1"])`)
         );
 
         if (regions.length) {
             const regionElements: pxt.Map<Element> = {};
 
             for (const region of regions) {
-                const el = container.querySelector(`[data-focus-trap-region="${region.id}"]`);
+                const el = container.current.querySelector(`[data-focus-trap-region="${region.id}"]`);
 
                 if (el) {
                     regionElements[region.id] = el;
@@ -98,10 +98,10 @@ const FocusTrapInner = (props: FocusTrapProps) => {
 
     const handleRef = React.useCallback((ref: HTMLDivElement) => {
         if (!ref) return;
-        container = ref;
+        container.current = ref;
 
         if (!dontStealFocus && !stoleFocus && !ref.contains(document.activeElement) && getElements().length) {
-            container.focus();
+            container.current.focus();
 
             // Only steal focus once
             setStoleFocus(true);
@@ -109,7 +109,7 @@ const FocusTrapInner = (props: FocusTrapProps) => {
     }, [getElements, dontStealFocus, stoleFocus]);
 
     const onKeyDown = React.useCallback((e: React.KeyboardEvent) => {
-        if (!container) return;
+        if (!container.current) return;
 
         const moveFocus = (forward: boolean, goToEnd: boolean) => {
             const focusable = getElements();
@@ -150,7 +150,7 @@ const FocusTrapInner = (props: FocusTrapProps) => {
             if (regions.length) {
                 for (const region of regions) {
                     if (!region.onEscape) continue;
-                    const regionElement = container.querySelector(`[data-focus-trap-region="${region.id}"]`);
+                    const regionElement = container.current.querySelector(`[data-focus-trap-region="${region.id}"]`);
                     if (regionElement?.contains(document.activeElement)) {
                         foundHandler = true;
                         region.onEscape();

--- a/react-common/components/controls/RadioButtonGroup.tsx
+++ b/react-common/components/controls/RadioButtonGroup.tsx
@@ -42,14 +42,14 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
             childTabStopId={selectedId}>
             {choices.map(choice =>
                 <div key={choice.id}
-                    className={classList("common-radio-choice", choice.className, selectedId === choice.id && "selected" )}
-                    onClick={() => onChoiceClick(choice.id)}>
+                    className={classList("common-radio-choice", choice.className, selectedId === choice.id && "selected" )}>
                     <input
                         type="radio"
                         id={choice.id}
                         value={choice.id}
                         name={id + "-input"}
                         checked={selectedId === choice.id}
+                        onChange={() => onChoiceClick(choice.id)}
                         tabIndex={0}
                         aria-label={choice.label ? undefined : choice.title}
                         aria-labelledby={choice.label ? choice.id + "-label" : undefined} />

--- a/react-common/styles/controls/DraggableGraph.less
+++ b/react-common/styles/controls/DraggableGraph.less
@@ -20,6 +20,9 @@
 
 .draggable-graph-surface {
     cursor: pointer;
+    &:focus {
+        outline: none;
+    }
 }
 
 .draggable-graph-svg {

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -42,10 +42,6 @@
         margin: 0;
         width: 100%;
     }
-
-    .common-button:focus::after {
-        outline: none;
-    }
 }
 
 .common-editor-toggle-item.common-editor-toggle-item-dropdown {
@@ -66,6 +62,14 @@
 
     & > .common-button {
         color: var(--pxt-neutral-foreground2);
+    }
+}
+
+.common-editor-toggle-item.focused {
+    outline: 3px solid var(--pxt-neutral-background2);
+    outline-offset: -5px;
+    &.selected {
+        outline: 3px solid var(--pxt-focus-border);
     }
 }
 
@@ -136,12 +140,8 @@
  ****************************************************/
 
 .common-toggle-accessibility {
-    position: absolute;
-    z-index: 2;
     width: 0px;
     height: 0px;
-    left: 0;
-    background: white;
 
     .common-button {
         width: 0px;
@@ -154,16 +154,8 @@
         top: 0;
         left: 0;
     }
-    .common-button:focus {
-        width: 100%;
-        height: 100%;
-    }
 }
 
-.common-toggle-accessibility:focus-within {
-    width: 100%;
-    height: 100%;
-}
 
 
 /*****************************************************

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -66,7 +66,7 @@
 }
 
 .common-editor-toggle-item.focused {
-    outline: 3px solid var(--pxt-neutral-background2);
+    outline: 3px solid var(--pxt-neutral-foreground2);
     outline-offset: -5px;
     &.selected {
         outline: 3px solid var(--pxt-focus-border);

--- a/react-common/styles/controls/EditorToggle.less
+++ b/react-common/styles/controls/EditorToggle.less
@@ -139,7 +139,9 @@
  *                Accessibility Menu                 *
  ****************************************************/
 
+/* Hidden, duplicates the visible structure but for keyboard users */
 .common-toggle-accessibility {
+    position: absolute;
     width: 0px;
     height: 0px;
 

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -63,6 +63,13 @@
     }
 }
 
+#sound-effect-editor-toggle > .common-editor-toggle-item.focused {
+    outline: 3px solid var(--pxt-neutral-background1);
+    &.selected {
+        outline: 3px solid var(--pxt-focus-border);
+    }
+}
+
 .common-button.link-button.generate-similar {
     margin-bottom: 0.5rem;
 }

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -37,6 +37,11 @@
     flex-grow: 1;
     position: relative;
     overflow: hidden;
+
+    .common-dropdown-item:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        outline-offset: -3px;
+    }
 }
 
 .sound-controls {

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -245,20 +245,14 @@
 
 .sound-gallery-scroller > .common-button {
     margin-bottom: 0.5rem;
-    padding: 0.6rem 1rem 0.6rem;
+    padding: 0.3rem 1rem 0.3rem 0.5rem;
 
     &:focus-visible {
         outline: 5px solid var(--pxt-focus-border);
         outline-offset: -7px;
-
-        span > i {
-            display: none;
-        }
-        .common-button-flex::after {
-            content: "P";
-        }
     }
 }
+
 
 .sound-gallery-item-label {
     display: flex;
@@ -270,6 +264,15 @@
         margin-top: 0;
         z-index: 2;
     }
+}
+
+.sound-gallery-item-label-inner {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-grow: 1;
+    margin-right: 0.5rem;
+    padding: 0.3rem 0 0.3rem 0.5rem;
 
     .sound-effect-name {
         font-size: 22px;

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -178,8 +178,9 @@
     }
 }
 
-.common-button.sound-effect-play-button:focus::after {
-    border-radius: 2rem;
+.common-button.sound-effect-play-button:focus-visible {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: 3px;
 }
 
 .sound-preview-baseline {
@@ -223,6 +224,18 @@
 .sound-gallery-scroller > .common-button {
     margin-bottom: 0.5rem;
     padding: 0.6rem 1rem 0.6rem;
+
+    &:focus-visible {
+        outline: 5px solid var(--pxt-focus-border);
+        outline-offset: -7px;
+
+        span > i {
+            display: none;
+        }
+        .common-button-flex::after {
+            content: "P";
+        }
+    }
 }
 
 .sound-gallery-item-label {

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -94,6 +94,12 @@
     & > span {
         flex-grow: 1;
     }
+
+    .common-dropdown-button:focus-visible,
+    .common-dropdown-item:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        outline-offset: -3px;
+    }
 }
 
 .frequency-graph {

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -149,6 +149,17 @@
     }
 }
 
+#waveform-select .common-radio-choice {
+    input:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+    }
+
+    &.selected {
+        background-color: var(--pxt-neutral-foreground1);
+        color: var(--pxt-neutral-background1);
+    }
+}
+
 /****************************************************
  *                     Preview                      *
  ****************************************************/

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -65,6 +65,13 @@
         right: 0;
         top: 0;
         border: none;
+        &:focus-visible {
+            outline: 3px solid var(--pxt-neutral-background1);
+            outline-offset: -7px;
+            &:after {
+                outline: none !important;
+            }
+        }
     }
 }
 

--- a/webapp/src/components/soundEffectEditor/SoundControls.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundControls.tsx
@@ -256,6 +256,7 @@ export const SoundControls = (props: SoundControlsProps) => {
                 <DraggableGraph
                     min={1}
                     max={pxt.assets.MAX_FREQUENCY}
+                    ariaLabel="Frequency over time"
                     aspectRatio={3}
                     valueUnits={pxt.U.lf("Hz")}
                     points={[sound.startFrequency, sound.endFrequency]}
@@ -274,12 +275,13 @@ export const SoundControls = (props: SoundControlsProps) => {
                 <DraggableGraph
                     min={0}
                     max={pxt.assets.MAX_VOLUME}
+                    ariaLabel="Volume over time"
                     aspectRatio={5}
                     points={[sound.startVolume, sound.endVolume]}
                     interpolation="linear"
                     onPointChange={onVolumeChange}
                     handleStartAnimationRef={handleVolumeAnimationRef}
-                    squiggly={sound.effect === "tremolo"}
+                    squiggly={sound.effect === "tremolo" || sound.effect === "warble"}
                 />
             </div>
         </div>

--- a/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
@@ -5,6 +5,7 @@ import { SoundEffectHeader } from "./SoundEffectHeader";
 import { SoundGallery } from "./SoundGallery";
 import { SoundPreview } from "./SoundPreview";
 import { getGallerySounds, soundToCodalSound } from "./soundUtil";
+import { FocusTrap, FocusTrapRegion } from "../../../../react-common/components/controls/FocusTrap";
 
 export interface SoundEffectEditorProps {
     onSoundChange?: (newValue: pxt.assets.Sound) => void;
@@ -116,6 +117,7 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
     }
 
     const handleSoundChange = (newSound: pxt.assets.Sound, setSoundSeed = true) => {
+        console.log("setting sound");
         if (cancelToken) cancel();
         if (setSoundSeed) setSimilarSoundSeed(undefined);
         if (onSoundChange) onSoundChange(newSound);
@@ -128,48 +130,55 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
     }
 
     return <div className="sound-effect-editor">
-        <SoundEffectHeader
-            selectedView={selectedView}
-            onViewSelected={onViewSelected}
-            onClose={handleClose}
-        />
-        <div className="sound-effect-editor-content">
-            <SoundPreview
-                sound={sound}
-                handleStartAnimationRef={handlePreviewAnimationRef}
-                handleSynthListenerRef={handleSynthListenerRef} />
-            <Button
-                className="sound-effect-play-button"
-                title={cancelToken ? lf("Stop") : lf("Play")}
-                onClick={handlePlayButtonClick}
-                leftIcon={cancelToken ? "fas fa-stop" : "fas fa-play"}
-                />
-            <SoundControls sound={sound} onSoundChange={handleSoundChange} handleStartAnimationRef={handleControlsAnimationRef} />
-            <Button
-                className="link-button generate-similar"
-                leftIcon="fas fa-sync"
-                label={pxt.U.lf("Generate Similar Sound")}
-                title={pxt.U.lf("Generate Similar Sound")}
-                onClick={() => {
-                    let newSound: pxt.assets.Sound;
-                    if (!similarSoundSeed) {
-                        setSimilarSoundSeed(sound);
-                        newSound = generateSimilarSound(sound);
-                    }
-                    else {
-                        newSound = generateSimilarSound(similarSoundSeed);
-                    }
-                    handleSoundChange(newSound, false);
-                    play(newSound);
-                }}
+        <FocusTrap onEscape={handleClose}>
+            <SoundEffectHeader
+                selectedView={selectedView}
+                onViewSelected={onViewSelected}
+                onClose={handleClose}
             />
-            <SoundGallery
-                sounds={getGallerySounds(useMixerSynthesizer)}
-                onSoundSelected={handleGallerySelection}
-                visible={selectedView === "gallery"}
-                useMixerSynthesizer={useMixerSynthesizer}
-                />
-        </div>
+            <div className="sound-effect-editor-content">
+                <FocusTrapRegion enabled={selectedView === "editor"}>
+                    <SoundPreview
+                        sound={sound}
+                        handleStartAnimationRef={handlePreviewAnimationRef}
+                        handleSynthListenerRef={handleSynthListenerRef} />
+                    <Button
+                        className="sound-effect-play-button"
+                        title={cancelToken ? lf("Stop") : lf("Play")}
+                        onClick={handlePlayButtonClick}
+                        leftIcon={cancelToken ? "fas fa-stop" : "fas fa-play"}
+                        />
+                    <SoundControls sound={sound} onSoundChange={handleSoundChange} handleStartAnimationRef={handleControlsAnimationRef} />
+                    <Button
+                        className="link-button generate-similar"
+                        leftIcon="fas fa-sync"
+                        label={pxt.U.lf("Generate Similar Sound")}
+                        title={pxt.U.lf("Generate Similar Sound")}
+                        onClick={() => {
+                            let newSound: pxt.assets.Sound;
+                            if (!similarSoundSeed) {
+                                setSimilarSoundSeed(sound);
+                                newSound = generateSimilarSound(sound);
+                            }
+                            else {
+                                newSound = generateSimilarSound(similarSoundSeed);
+                            }
+                            handleSoundChange(newSound, false);
+                            play(newSound);
+                        }}
+                    />
+                </FocusTrapRegion>
+
+                <FocusTrapRegion enabled={selectedView === "gallery"}>
+                    <SoundGallery
+                        sounds={getGallerySounds(useMixerSynthesizer)}
+                        onSoundSelected={handleGallerySelection}
+                        visible={selectedView === "gallery"}
+                        useMixerSynthesizer={useMixerSynthesizer}
+                        />
+                </FocusTrapRegion>
+            </div>
+        </FocusTrap>
     </div>
 }
 

--- a/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
@@ -52,6 +52,9 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
             // Ignore when a text input is focused
             if (document.activeElement && document.activeElement.tagName === "INPUT" && (document.activeElement as HTMLInputElement).type === "text") return;
 
+            // Ignore in gallery view
+            if (selectedView === "gallery") return;
+
             play();
         };
 
@@ -124,8 +127,9 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
     }
 
     const handleGallerySelection = (newSound: pxt.assets.Sound) => {
-        handleSoundChange(newSound)
+        handleSoundChange(newSound);
         setSelectedView("editor");
+        document.getElementById("sound-effect-play-button").focus();
     }
 
     return <div className="sound-effect-editor">
@@ -142,6 +146,7 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
                         handleStartAnimationRef={handlePreviewAnimationRef}
                         handleSynthListenerRef={handleSynthListenerRef} />
                     <Button
+                        id="sound-effect-play-button"
                         className="sound-effect-play-button"
                         title={cancelToken ? lf("Stop") : lf("Play")}
                         onClick={handlePlayButtonClick}

--- a/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundEffectEditor.tsx
@@ -117,7 +117,6 @@ export const SoundEffectEditor = (props: SoundEffectEditorProps) => {
     }
 
     const handleSoundChange = (newSound: pxt.assets.Sound, setSoundSeed = true) => {
-        console.log("setting sound");
         if (cancelToken) cancel();
         if (setSoundSeed) setSimilarSoundSeed(undefined);
         if (onSoundChange) onSoundChange(newSound);

--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -18,26 +18,63 @@ export interface SoundGalleryProps {
 
 interface SoundGalleryItemProps extends SoundGalleryItem {
     useMixerSynthesizer: boolean;
+    onClick: () => void;
+    selectReference: (el: HTMLDivElement) => void;
+    playReference: (el: HTMLButtonElement) => void;
+    previewKeyDown: (evt: React.KeyboardEvent<HTMLElement>) => void;
+    selectKeyDown: (evt: React.KeyboardEvent<HTMLElement>) => void;
 }
 
 export const SoundGallery = (props: SoundGalleryProps) => {
     const { sounds, onSoundSelected, visible, useMixerSynthesizer } = props;
 
-    const soundItemRefs = React.useRef<Record<string,HTMLElement>>({});
+    const selectItemRefs = React.useRef<Record<string,HTMLElement>>({});
+    const playItemRefs = React.useRef<Record<string,HTMLElement>>({});
 
-    function listNav(
+    function selectNav(
         prev: number,
         next: number,
+        current: number,
         event: React.KeyboardEvent<HTMLElement>) {
-            if (event.code === "ArrowDown") {
-                soundItemRefs.current[next].focus();
+            console.log("Selectnav", event.code);
+        switch(event.code) {
+            case "ArrowDown":
+                selectItemRefs.current[next].focus();
+                console.log("focused ",selectItemRefs.current, next);
                 event.preventDefault();
-            } else if (event.code === "ArrowUp") {
-                soundItemRefs.current[prev].focus();
+                break;
+            case "ArrowUp":
+                selectItemRefs.current[prev].focus();
                 event.preventDefault();
-            } else {
-                fireClickOnEnter(event);
-            }
+                break;
+            case "ArrowRight":
+                playItemRefs.current[current].focus();
+                event.preventDefault();
+                break;
+            default:
+        }
+    }
+
+    function previewNav(
+        prev: number,
+        next: number,
+        current: number,
+        event: React.KeyboardEvent<HTMLElement>) {
+        switch(event.code) {
+            case "ArrowDown":
+                playItemRefs.current[next].focus();
+                event.preventDefault();
+                break;
+            case "ArrowUp":
+                playItemRefs.current[prev].focus();
+                event.preventDefault();
+                break;
+            case "ArrowLeft":
+                selectItemRefs.current[current].focus();
+                event.preventDefault();
+                break;
+            default:
+        }
     }
 
     return <div className={classList("sound-gallery", visible && "visible")} aria-hidden={!visible}>
@@ -47,15 +84,20 @@ export const SoundGallery = (props: SoundGalleryProps) => {
                     const next = (index + 1) % sounds.length;
                     return(<div
                         key={index}
-                        ref={ref => soundItemRefs.current[index] = ref}
-                        className="common-button"
-                        title={item.name}
-                        role="button"
-                        tabIndex={0}
-                        onKeyDown={e => listNav(prev, next, e)}
-                        onClick={() => onSoundSelected(item.sound)}>
+                        onClick={() => onSoundSelected(item.sound)}
+                        className="common-button">
 
-                        <SoundGalleryEntry {...item} useMixerSynthesizer={useMixerSynthesizer} />
+                        <SoundGalleryEntry
+                            {...item}
+                            useMixerSynthesizer={useMixerSynthesizer}
+                            onClick={() => onSoundSelected(item.sound)}
+
+                            playReference={ref => playItemRefs.current[index] = ref}
+                            selectReference={ref => selectItemRefs.current[index] = ref}
+
+                            previewKeyDown={evt => previewNav(prev, next, index, evt)}
+                            selectKeyDown={evt => selectNav(prev, next, index, evt)}
+                        />
                     </div>);
                 })
             }
@@ -64,7 +106,16 @@ export const SoundGallery = (props: SoundGalleryProps) => {
 }
 
 const SoundGalleryEntry = (props: SoundGalleryItemProps) => {
-    const { sound, name, useMixerSynthesizer } = props;
+    const { 
+        sound,
+        name,
+        onClick,
+        useMixerSynthesizer,
+        playReference,
+        selectReference,
+        previewKeyDown,
+        selectKeyDown
+    } = props;
     const width = 160;
     const height = 40;
 
@@ -92,22 +143,32 @@ const SoundGalleryEntry = (props: SoundGalleryItemProps) => {
     }
 
     return <div className="sound-gallery-item-label">
-        <div className="sound-effect-name">
-            {name}
-        </div>
-        <div className="sound-gallery-preview">
-            <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
-                <path
-                    className="sound-gallery-preview-wave"
-                    d={pxt.assets.renderSoundPath(sound, width, height)}
-                    strokeWidth="2"
-                    fill="none"/>
-            </svg>
+        <div className="sound-gallery-item-label-inner"
+            tabIndex={0}
+            ref={selectReference}
+            onClick={onClick}
+            onKeyDown={selectKeyDown}
+            title={name}
+            role="button">
+            <div className="sound-effect-name">
+                {name}
+            </div>
+            <div className="sound-gallery-preview">
+                <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        className="sound-gallery-preview-wave"
+                        d={pxt.assets.renderSoundPath(sound, width, height)}
+                        strokeWidth="2"
+                        fill="none"/>
+                </svg>
+            </div>
         </div>
         <Button
             className="sound-effect-play-button"
+            buttonRef={playReference}
             title={cancelToken ? lf("Stop Sound Preview") : lf("Preview Sound")}
             onClick={handlePlayButtonClick}
+            onKeydown={previewKeyDown}
             leftIcon={cancelToken ? "fas fa-stop" : "fas fa-play"}
             />
     </div>

--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -23,25 +23,45 @@ interface SoundGalleryItemProps extends SoundGalleryItem {
 export const SoundGallery = (props: SoundGalleryProps) => {
     const { sounds, onSoundSelected, visible, useMixerSynthesizer } = props;
 
+    const soundItemRefs = React.useRef<Record<string,HTMLElement>>({});
+
+    function listNav(
+        prev: number,
+        next: number,
+        event: React.KeyboardEvent<HTMLElement>) {
+            if (event.code === "ArrowDown") {
+                soundItemRefs.current[next].focus();
+                event.preventDefault();
+            } else if (event.code === "ArrowUp") {
+                soundItemRefs.current[prev].focus();
+                event.preventDefault();
+            } else {
+                fireClickOnEnter(event);
+            }
+    }
+
     return <div className={classList("sound-gallery", visible && "visible")} aria-hidden={!visible}>
         <div className="sound-gallery-scroller">
-            {sounds.map((item, index) =>
-                <div
-                    key={index}
-                    className="common-button"
-                    title={item.name}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={fireClickOnEnter}
-                    onClick={() => onSoundSelected(item.sound)}>
+            {sounds.map((item, index) => {
+                    const prev = (index + sounds.length - 1) % sounds.length;
+                    const next = (index + 1) % sounds.length;
+                    return(<div
+                        key={index}
+                        ref={ref => soundItemRefs.current[index] = ref}
+                        className="common-button"
+                        title={item.name}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={e => listNav(prev, next, e)}
+                        onClick={() => onSoundSelected(item.sound)}>
 
-                    <SoundGalleryEntry {...item} useMixerSynthesizer={useMixerSynthesizer} />
-                </div>
-            )}
+                        <SoundGalleryEntry {...item} useMixerSynthesizer={useMixerSynthesizer} />
+                    </div>);
+                })
+            }
         </div>
     </div>
 }
-
 
 const SoundGalleryEntry = (props: SoundGalleryItemProps) => {
     const { sound, name, useMixerSynthesizer } = props;

--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -51,6 +51,11 @@ export const SoundGallery = (props: SoundGalleryProps) => {
                 playItemRefs.current[current].focus();
                 event.preventDefault();
                 break;
+            case "Space":
+            case "Enter":
+                selectItemRefs.current[current].click();
+                event.stopPropagation();
+                event.preventDefault();
             default:
         }
     }


### PR DESCRIPTION
Just creating this draft for conversation about the change to [react-common/components/controls/Input.tsx](https://github.com/microbit-matt-hillsdon/pxt/pull/40/files#diff-5fc845453c37078332078e326ce1a4cd487b0640b3edeadab42f8e29fb68959a), ignore the rest for now.

Changes in this PR
* Escape key closes the input box without closing the editor
* One tab stop per input with dropdown, open with ArrowDown

<img width="153" alt="image" src="https://github.com/user-attachments/assets/bc0b2532-7a2c-400c-b16b-3111bb8ecc79" />

For the Duration(ms) field in the Sound Effect editor, I could not figure out a decent way to make Escape close the dropdown menu without closing the whole editor pane. After some investigation, I found that Blockly was capturing the escape at a document level. This approach uses a useEffect to suspend the Blockly keyboard event until the dropdown is closed, and seems like the least invasive way to do it, but it still feels like a sledgehammer. I would like to know if you think it's too much, or if I have missed some simpler strategy.