### PR TITLE
Use 'ESC' to close keyboard help docs when focused

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -697,14 +697,9 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
             || this.state.docsUrl != nextState.docsUrl;
     }
 
-    protected handleRef = (el: HTMLDivElement) => {
-        if (el) {
-            el.addEventListener("keydown", (ev: KeyboardEvent) => {
-                if (ev.key == "Escape") {
-                    ev.preventDefault();
-                    this.collapse();
-                }
-            });
+    protected handleOnKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (ev) => {
+        if (ev.key == "Escape") {
+            this.collapse();
         }
     }
 
@@ -724,7 +719,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
             <button id="sidedocstoggle" role="button" aria-label={sideDocsCollapsed ? lf("Expand the side documentation") : lf("Collapse the side documentation")} className="ui icon button large" onClick={this.toggleVisibility}>
                 <sui.Icon icon={`icon inverted chevron ${showLeftChevron ? 'left' : 'right'}`} />
             </button>
-            <div id="sidedocs" ref={this.handleRef}>
+            <div id="sidedocs" onKeyDown={this.handleOnKeyDown}>
                 <div id="sidedocsframe-wrapper">
                     {this.renderContent(url, isBuiltIn, lockedEditor)}
                 </div>

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -697,7 +697,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
             || this.state.docsUrl != nextState.docsUrl;
     }
 
-    protected handleOnKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (ev) => {
+    protected handleOnKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
         if (ev.key == "Escape") {
             this.collapse();
         }

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -697,6 +697,17 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
             || this.state.docsUrl != nextState.docsUrl;
     }
 
+    protected handleRef = (el: HTMLDivElement) => {
+        if (el) {
+            el.addEventListener("keydown", (ev: KeyboardEvent) => {
+                if (ev.key == "Escape") {
+                    ev.preventDefault();
+                    this.collapse();
+                }
+            });
+        }
+    }
+
     renderCore() {
         const { sideDocsCollapsed, docsUrl } = this.state;
         const isRTL = pxt.Util.isUserLanguageRtl();
@@ -713,7 +724,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
             <button id="sidedocstoggle" role="button" aria-label={sideDocsCollapsed ? lf("Expand the side documentation") : lf("Collapse the side documentation")} className="ui icon button large" onClick={this.toggleVisibility}>
                 <sui.Icon icon={`icon inverted chevron ${showLeftChevron ? 'left' : 'right'}`} />
             </button>
-            <div id="sidedocs">
+            <div id="sidedocs" ref={this.handleRef}>
                 <div id="sidedocsframe-wrapper">
                     {this.renderContent(url, isBuiltIn, lockedEditor)}
                 </div>


### PR DESCRIPTION
This does not work for reference docs due to the keydown event happening in an iframe