### PR TITLE
Soundeffect editor accessibility

### DIFF
--- a/cli/nodeutil.ts
+++ b/cli/nodeutil.ts
@@ -284,7 +284,7 @@ export async function npmVersionBumpAsync(
 ): Promise<string> {
     const output = await spawnWithPipeAsync({
         cmd: addCmd("npm"),
-        args: ["version", bumpType, "--message", `"[pxt-cli] bump version to %s"`, "--git-tag-version", tagCommit ? "true" : "false"],
+        args: ["version", bumpType, "--message", quoteIfNeeded(`[pxt-cli] bump version to %s`), "--git-tag-version", tagCommit ? "true" : "false"],
         cwd: ".",
         silent: true,
     });
@@ -299,12 +299,19 @@ export async function npmVersionBumpAsync(
         });
         await spawnAsync({
             cmd: "git",
-            args: ["commit", "-m", `"[pxt-cli] bump version to ${ver}"`],
+            args: ["commit", "-m", quoteIfNeeded(`[pxt-cli] bump version to ${ver}`)],
             cwd: ".",
             silent: true,
         });
     }
     return ver;
+}
+
+function quoteIfNeeded(arg: string) {
+    if (os.platform() === "win32") {
+        return `"${arg}"`;
+    }
+    return arg;
 }
 
 export function gitPushAsync(followTags: boolean = true) {

--- a/docfiles/style.css
+++ b/docfiles/style.css
@@ -185,7 +185,7 @@ svg {
     line-height: 4em;
     font-size: 1em;
     text-align: center;
-    color: #387894;
+    color: black;
     background: hsla(0,0%,100%,.9)!important;
 }
 

--- a/libs/pxt-common/pxt-core.d.ts
+++ b/libs/pxt-common/pxt-core.d.ts
@@ -307,8 +307,12 @@ declare interface String {
      */
     //% helper=stringSubstr
     //% help=text/substr
-    //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
+    //% blockId=string_substr_new
+    //% block="substring of $this|from $start||of length $length"
+    //% this.shadow="text"
     //% this.defl="this"
+    //% blockNamespace="text"
+    //% expandArgumentsInToolbox
     substr(start: number, length?: number): string;
 
     /**
@@ -402,6 +406,19 @@ declare interface String {
     //% helper=stringToLowerCase
     //% help=text/to-lower-case
     toLowerCase(): string;
+
+    /**
+     * Return a substring of the current string.
+     * @param start first character index; can be negative from counting from the end, eg:0
+     * @param length number of characters to extract, eg: 10
+     */
+    //% helper=stringSubstr
+    //% help=text/substr
+    //% blockId="string_substr" block="substring of %this=text|from %start|of length %length" blockNamespace="text"
+    //% this.defl="this"
+    //% blockAliasFor="String.substr"
+    //% deprecated
+    __substr(start: number, length?: number): string;
 
     [index: number]: string;
 }

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -134,6 +134,7 @@ declare namespace pxt {
         uploadDocs?: boolean; // enable uploading to crowdin on master or v* builds
         variants?: Map<AppTarget>; // patches on top of the current AppTarget for different chip variants
         multiVariants?: string[];
+        disabledVariants?: string[];
         alwaysMultiVariant?: boolean;
         queryVariants?: Map<AppTarget>; // patches on top of the current AppTarget using query url regex
         unsupportedBrowsers?: BrowserOptions[]; // list of unsupported browsers for a specific target (eg IE11 in arcade). check browserutils.js browser() function for strings

--- a/localtypings/pxtarget.d.ts
+++ b/localtypings/pxtarget.d.ts
@@ -948,6 +948,7 @@ declare namespace ts.pxtc {
         inlineInputModeLimit?: number; // the number of expanded arguments at which to switch from inline to external. only applies when inlineInputMode=variable and expandableArgumentsMode=enabled
         expandableArgumentMode?: string; // can be disabled, enabled, or toggle
         expandableArgumentBreaks?: string; // a comma separated list of how many arguments to reveal/hide each time + or - is pressed on a block. only applies when expandableArgumentsMode=enabled
+        expandArgumentsInToolbox?: boolean; // if true, the block will be fully expanded in the toolbox flyout
         compileHiddenArguments?: boolean; // if true, compiles the values in expandable arguments even when collapsed
         draggableParameters?: string; // can be reporter or variable; defaults to variable
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "11.4.20",
+  "version": "11.4.21",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/package.json
+++ b/package.json
@@ -156,6 +156,9 @@
     "yargs": "^17.7.2"
   },
   "overrides": {
+    "combine-source-map": {
+      "source-map": "0.4.4"
+    },
     "@blockly/field-colour": {
       "blockly": "^12.0.0-beta.4"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "11.4.18",
+  "version": "11.4.20",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "11.4.17",
+  "version": "11.4.18",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtblocks/fields/field_sound_effect.ts
+++ b/pxtblocks/fields/field_sound_effect.ts
@@ -128,7 +128,8 @@ export class FieldSoundEffect extends FieldBase<FieldSoundEffectParams> {
         this.fieldGroup_.appendChild(g.el);
     }
 
-    showEditor_() {
+    showEditor_(e: Event) {
+        const keyboardTriggered = !e;
         const initialSound = this.readCurrentSound();
         Blockly.Events.disable();
 
@@ -186,7 +187,7 @@ export class FieldSoundEffect extends FieldBase<FieldSoundEffectParams> {
             useMixerSynthesizer: isTrue(this.options.useMixerSynthesizer)
         }
 
-        const fv = pxt.react.getFieldEditorView("soundeffect-editor", initialSound, opts, widgetDiv);
+        const fv = pxt.react.getFieldEditorView("soundeffect-editor", initialSound, opts, widgetDiv, keyboardTriggered);
 
         const block = this.sourceBlock_ as Blockly.BlockSvg;
         const bounds = block.getBoundingRectangle();

--- a/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
+++ b/pxtblocks/plugins/functions/blocks/argumentReporterBlocks.ts
@@ -10,6 +10,8 @@ import { MsgKey } from "../msg";
 import { DUPLICATE_ON_DRAG_MUTATION_KEY, setDuplicateOnDragStrategy } from "../../duplicateOnDrag";
 import { PathObject } from "../../renderer/pathObject";
 
+export const LOCALIZATION_NAME_MUTATION_KEY = "localizationname";
+
 type ArgumentReporterMixinType = typeof ARGUMENT_REPORTER_MIXIN;
 
 interface ArgumentReporterMixin extends ArgumentReporterMixinType {}
@@ -18,16 +20,24 @@ export type ArgumentReporterBlock = Blockly.BlockSvg & ArgumentReporterMixin;
 
 const ARGUMENT_REPORTER_MIXIN = {
     typeName_: "",
+    localizationName_: "",
     duplicateOnDrag_: false,
 
     getTypeName(this: ArgumentReporterBlock) {
         return this.typeName_;
     },
 
+    getLocalizationName(this: ArgumentReporterBlock) {
+        return this.localizationName_ || this.getFieldValue("VALUE");
+    },
+
     mutationToDom(this: ArgumentReporterBlock) {
         const container = Blockly.utils.xml.createElement("mutation");
         if (this.duplicateOnDrag_) {
             container.setAttribute(DUPLICATE_ON_DRAG_MUTATION_KEY, "true");
+        }
+        if (this.localizationName_) {
+            container.setAttribute(LOCALIZATION_NAME_MUTATION_KEY, this.localizationName_);
         }
         return container;
     },
@@ -39,6 +49,9 @@ const ARGUMENT_REPORTER_MIXIN = {
                 (this.pathObject as PathObject).setHasDottedOutlineOnHover(this.duplicateOnDrag_);
             }
         }
+        if (xmlElement.hasAttribute(LOCALIZATION_NAME_MUTATION_KEY)) {
+            this.localizationName_ = xmlElement.getAttribute(LOCALIZATION_NAME_MUTATION_KEY);
+        }
     },
 };
 
@@ -49,7 +62,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_BOOLEAN_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -69,7 +82,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_STRING_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -89,7 +102,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_NUMBER_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -109,7 +122,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_ARRAY_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },
@@ -129,7 +142,7 @@ Blockly.Blocks[ARGUMENT_REPORTER_CUSTOM_BLOCK_TYPE] = {
             message0: " %1",
             args0: [
                 {
-                    type: "field_label_serializable",
+                    type: "field_argument_reporter",
                     name: "VALUE",
                     text: "",
                 },

--- a/pxtblocks/plugins/functions/fields/fieldArgumentReporter.ts
+++ b/pxtblocks/plugins/functions/fields/fieldArgumentReporter.ts
@@ -1,0 +1,21 @@
+import * as Blockly from "blockly";
+import { isFunctionArgumentReporter } from "../utils";
+import { ArgumentReporterBlock } from "../blocks/argumentReporterBlocks";
+
+export class FieldArgumentReporter extends Blockly.FieldLabelSerializable {
+    protected override getDisplayText_(): string {
+        const source = this.getSourceBlock();
+        if (source && isFunctionArgumentReporter(source)) {
+            const localizeKey = (source as ArgumentReporterBlock).getLocalizationName();
+
+            const localized = localizeKey && pxt.U.rlf(localizeKey);
+            if (localized && localized !== localizeKey) {
+                return localized;
+            }
+        }
+
+        return super.getDisplayText_();
+    }
+}
+
+Blockly.registry.register(Blockly.registry.Type.FIELD, "field_argument_reporter", FieldArgumentReporter);

--- a/pxtblocks/plugins/functions/index.ts
+++ b/pxtblocks/plugins/functions/index.ts
@@ -1,6 +1,7 @@
 export * from "./msg";
 export * from "./extensions";
 export * from "./fields/fieldArgumentEditor";
+export * from "./fields/fieldArgumentReporter";
 export * from "./fields/fieldAutocapitalizeTextInput";
 export * from "./blocks/argumentEditorBlocks";
 export * from "./blocks/argumentReporterBlocks";

--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -453,6 +453,24 @@ export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, c
         }
     }
 
+    if (fn.attributes.expandArgumentsInToolbox) {
+        let mutation: Element;
+
+        for (const child of block.children) {
+            if (child.tagName === "mutation") {
+                mutation = child;
+                break;
+            }
+        }
+
+        if (!mutation) {
+            mutation = document.createElement("mutation");
+            block.appendChild(mutation);
+        }
+
+        mutation.setAttribute("_expanded", "" + fn.attributes._expandedDef.parameters.length);
+    }
+
     if (parent) {
         parentInput.appendChild(block);
         return parent;

--- a/pxtblocks/toolbox.ts
+++ b/pxtblocks/toolbox.ts
@@ -1,7 +1,7 @@
 /// <reference path="../built/pxtlib.d.ts" />
 
 import * as Blockly from "blockly";
-import { flyoutCategory, getAllFunctionDefinitionBlocks } from "./plugins/functions";
+import { flyoutCategory, getAllFunctionDefinitionBlocks, LOCALIZATION_NAME_MUTATION_KEY } from "./plugins/functions";
 import { DUPLICATE_ON_DRAG_MUTATION_KEY } from "./plugins/duplicateOnDrag";
 import { DRAGGABLE_PARAM_INPUT_PREFIX } from "./loader";
 
@@ -433,9 +433,11 @@ export function createToolboxBlock(info: pxtc.BlocksInfo, fn: pxtc.SymbolInfo, c
                 if (useReporter && blockType === "argument_reporter_custom") {
                     mutation.setAttribute("typename", arg.type);
                 }
+                mutation.setAttribute(LOCALIZATION_NAME_MUTATION_KEY, arg.localizationKey);
 
                 const field = document.createElement("field");
                 field.setAttribute("name", useReporter ? "VALUE" : "VAR");
+
                 field.textContent = pxt.Util.htmlEscape(arg.name);
 
                 shadow.appendChild(field);

--- a/pxtcompiler/emitter/service.ts
+++ b/pxtcompiler/emitter/service.ts
@@ -336,8 +336,6 @@ namespace ts.pxtc {
             }
             if (si.attributes.jsDoc)
                 jsdocStrings[si.qName] = si.attributes.jsDoc;
-            if (si.attributes.block)
-                locStrings[`${si.qName}|block`] = si.attributes.block;
             if (si.attributes.group)
                 locStrings[`{id:group}${si.attributes.group}`] = si.attributes.group;
             if (si.attributes.subcategory)
@@ -346,6 +344,16 @@ namespace ts.pxtc {
                 si.parameters.filter(pi => !!pi.description).forEach(pi => {
                     jsdocStrings[`${si.qName}|param|${pi.name}`] = pi.description;
                 })
+
+            if (si.attributes.block) {
+                locStrings[`${si.qName}|block`] = si.attributes.block;
+                const comp = pxt.blocks.compileInfo(si);
+                if (comp.handlerArgs?.length) {
+                    for (const arg of comp.handlerArgs) {
+                        locStrings[arg.localizationKey] = arg.name;
+                    }
+                }
+            }
         }
         const mapLocs = (m: pxt.Map<string>, name: string) => {
             if (!options.locs) return;

--- a/pxtlib/blocks.ts
+++ b/pxtlib/blocks.ts
@@ -81,9 +81,10 @@ namespace pxt.blocks {
     }
 
     export interface HandlerArg {
-        name: string,
-        type: string,
-        inBlockDef: boolean
+        name: string;
+        type: string;
+        inBlockDef: boolean;
+        localizationKey: string;
     }
 
     // Information for blocks that compile to function calls but are defined by vanilla Blockly
@@ -215,7 +216,8 @@ namespace pxt.blocks {
                         res.handlerArgs.push({
                             name: arg.name,
                             type: arg.type,
-                            inBlockDef: defParameters ? defParameters.some(def => def.ref && def.name === arg.name) : false
+                            inBlockDef: defParameters ? defParameters.some(def => def.ref && def.name === arg.name) : false,
+                            localizationKey: `${fn.qName}|handlerParam|${arg.name}`
                         });
                     })
                 }

--- a/pxtlib/package.ts
+++ b/pxtlib/package.ts
@@ -1158,6 +1158,8 @@ namespace pxt {
                 }
             }
 
+            const disabledVariants = pxt.appTarget.disabledVariants;
+
             let shimsGenerated = false
 
             const fillExtInfoAsync = async (variant: string) => {
@@ -1216,10 +1218,14 @@ namespace pxt {
                     variants = [pxt.appTargetVariant]
                 } else if (pxt.appTarget.alwaysMultiVariant || pxt.appTarget.compile.switches.multiVariant) {
                     // multivariants enabled
-                    variants = pxt.appTarget.multiVariants
+                    variants = pxt.appTarget.multiVariants;
                 } else {
                     // not enbaled - default to first variant
                     variants = [pxt.appTarget.multiVariants[0]]
+                }
+
+                if (!pxt.appTarget.alwaysMultiVariant && disabledVariants) {
+                    variants = variants.filter(v => !disabledVariants.includes(v));
                 }
             } else {
                 // no multi-variants, use empty variant name,
@@ -1239,6 +1245,9 @@ namespace pxt {
                         const einfo = etarget.extinfo;
                         einfo.appVariant = v;
                         einfo.outputPrefix = variants.length == 1 || !v ? "" : v + "-";
+                        if (disabledVariants?.indexOf(v) > -1) {
+                            einfo.disabledDeps = einfo.disabledDeps || "user-disabled";
+                        }
                         if (ext) {
                             opts.otherMultiVariants.push(etarget);
                         }

--- a/pxtlib/react.ts
+++ b/pxtlib/react.ts
@@ -10,6 +10,6 @@ namespace pxt.react {
     }
 
     export let isFieldEditorViewVisible: () => boolean;
-    export let getFieldEditorView: <U>(fieldEditorId: string, value: U, options: any, container?: HTMLDivElement) => FieldEditorView<U>;
+    export let getFieldEditorView: <U>(fieldEditorId: string, value: U, options: any, container?: HTMLDivElement, keyboardTriggered?: boolean) => FieldEditorView<U>;
     export let getTilemapProject: () => TilemapProject;
 }

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -835,8 +835,15 @@ namespace ts.pxtc {
         return r;
     }
 
-    const numberAttributes = ["weight", "imageLiteral", "gridLiteral", "topblockWeight", "inlineInputModeLimit"]
-    const booleanAttributes = [
+    const numberAttributes: (keyof CommentAttrs)[] = [
+        "weight",
+        "imageLiteral",
+        "gridLiteral",
+        "topblockWeight",
+        "inlineInputModeLimit"
+    ];
+
+    const booleanAttributes: (keyof CommentAttrs)[] = [
         "advanced",
         "handlerStatement",
         "afterOnStart",
@@ -851,7 +858,8 @@ namespace ts.pxtc {
         "callInDebugger",
         "duplicateShadowOnDrag",
         "argsNullable",
-        "compileHiddenArguments"
+        "compileHiddenArguments",
+        "expandArgumentsInToolbox",
     ];
 
     export function parseCommentString(cmt: string): CommentAttrs {

--- a/react-common/components/controls/DraggableGraph.tsx
+++ b/react-common/components/controls/DraggableGraph.tsx
@@ -35,6 +35,8 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
         valueUnits
     } = props;
 
+    const [focusedIndex, setFocusedIndex] = React.useState<number | undefined>();
+ 
     const width = 1000;
     const height = (1 / aspectRatio) * width;
 
@@ -109,6 +111,19 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                 const svg = screenToSVGCoord(ref.ownerSVGElement, coord);
                 throttledSetDragValue(index, svgCoordToValue(svg));
             };
+
+            ref.onkeydown = ev => {
+                const step = (max - min) / 100;
+                if (ev.code === "ArrowDown" || ev.code === "ArrowLeft") {
+                    onPointChange(index, Math.max(min, points[index] - step));
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                } else if (ev.code === "ArrowUp" || ev.code === "ArrowRight") {
+                    onPointChange(index, Math.min(max, points[index] + step));
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                } 
+            }
         });
     }, [dragIndex, onPointChange])
 
@@ -184,6 +199,19 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                             fill="white"
                             filter="url(#dropshadow)"
                         />
+
+                        {focusedIndex === index && 
+                            <circle
+                                className="draggable-graph-point-focus"
+                                cx={x + halfUnit}
+                                cy={y}
+                                r={unit+4}
+                                stroke="var(--pxt-focus-border)"
+                                fill="transparent"
+                                strokeWidth={8}
+                            />
+                        }
+
                         <text
                             className="common-draggable-graph-text"
                             x={isNotLast ? x + unit * 2 : x - unit}
@@ -201,7 +229,14 @@ export const DraggableGraph = (props: DraggableGraphProps) => {
                             height={height}
                             fill="white"
                             opacity={0}
-
+                            tabIndex={0}
+                            role="slider"
+                            aria-label={lf("{0}, position {1}", ariaLabel, index)}
+                            aria-valuemin={min}
+                            aria-valuemax={max}
+                            aria-valuenow={getValue(index)}
+                            onFocus={() => setFocusedIndex(index)}
+                            onBlur={() => focusedIndex === index && setFocusedIndex(undefined)}
                             />
                     </g>
             })}

--- a/react-common/components/controls/Input.tsx
+++ b/react-common/components/controls/Input.tsx
@@ -108,8 +108,12 @@ export const Input = (props: InputProps) => {
                 e.preventDefault();
                 onEnterKey(value);
             }
-        } else if (options && expanded && e.key === "ArrowDown") {
-            document.getElementById(getDropdownOptionId(Object.values(options)[0]))?.focus();
+        } else if (options && e.key === "ArrowDown") {
+            if (expanded) {
+                document.getElementById(getDropdownOptionId(Object.values(options)[0]))?.focus();
+            } else {
+                expandButtonClickHandler();
+            }
             e.preventDefault();
             e.stopPropagation();
         } else if (options && expanded && e.key === "ArrowUp") {
@@ -118,6 +122,15 @@ export const Input = (props: InputProps) => {
             e.preventDefault();
             e.stopPropagation();
         }
+    }
+
+    const captureEscapeKey = (e: React.KeyboardEvent) => {
+        if (e.code !== "Escape") return;
+        (e.target as HTMLElement).blur();
+        expandButtonClickHandler();
+        document.getElementById(id)?.focus();
+        e.stopPropagation();
+        e.preventDefault();
     }
 
     const iconClickHandler = () => {
@@ -212,6 +225,7 @@ export const Input = (props: InputProps) => {
                         ariaHasPopup="listbox"
                         ariaExpanded={expanded}
                         ariaLabel={ariaLabel}
+                        tabIndex={-1}
                         onClick={expandButtonClickHandler} />}
             </div>
             {expanded &&
@@ -220,7 +234,8 @@ export const Input = (props: InputProps) => {
                     childTabStopId={getDropdownOptionId(value) ?? getDropdownOptionId(Object.values(options)[0])}
                     aria-labelledby={id}
                     useUpAndDownArrowKeys={true}>
-                        <ul role="presentation">
+                        <ul role="presentation"
+                        onKeyDown={captureEscapeKey}>
                             { Object.keys(options).map(option =>
                                 <li key={option} role="presentation">
                                     <Button

--- a/react-common/components/controls/RadioButtonGroup.tsx
+++ b/react-common/components/controls/RadioButtonGroup.tsx
@@ -42,14 +42,14 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
             childTabStopId={selectedId}>
             {choices.map(choice =>
                 <div key={choice.id}
-                    className={classList("common-radio-choice", choice.className, selectedId === choice.id && "selected" )}
-                    onClick={() => onChoiceClick(choice.id)}>
+                    className={classList("common-radio-choice", choice.className, selectedId === choice.id && "selected" )}>
                     <input
                         type="radio"
                         id={choice.id}
                         value={choice.id}
                         name={id + "-input"}
                         checked={selectedId === choice.id}
+                        onChange={() => onChoiceClick(choice.id)}
                         tabIndex={0}
                         aria-label={choice.label ? undefined : choice.title}
                         aria-labelledby={choice.label ? choice.id + "-label" : undefined} />

--- a/react-common/styles/controls/DraggableGraph.less
+++ b/react-common/styles/controls/DraggableGraph.less
@@ -20,6 +20,9 @@
 
 .draggable-graph-surface {
     cursor: pointer;
+    &:focus {
+        outline: none;
+    }
 }
 
 .draggable-graph-svg {

--- a/tests/decompile-test/baselines/block_text.blocks
+++ b/tests/decompile-test/baselines/block_text.blocks
@@ -101,7 +101,8 @@
 <field name="VAR">f</field>
 <value name="VALUE">
 <shadow type="math_number"><field name="NUM">0</field></shadow>
-<block type="string_substr">
+<block type="string_substr_new">
+<mutation _expanded="1" />
 <value name="this">
 <shadow type="text">
 <field name="TEXT">abcdef</field>

--- a/theme/accessibility.less
+++ b/theme/accessibility.less
@@ -11,7 +11,7 @@
 *******************************/
 
 @accessibleMenuBackground: rgba(255,255,255,.9);
-@accessibleMenuColor: #387894;
+@accessibleMenuColor: black;
 
 /* Main menu focus */
 #mainmenu .ui.item:focus {

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -65,6 +65,13 @@
         right: 0;
         top: 0;
         border: none;
+        &:focus-visible {
+            outline: 3px solid var(--pxt-neutral-background1);
+            outline-offset: -7px;
+            &:after {
+                outline: none !important;
+            }
+        }
     }
 }
 
@@ -93,6 +100,12 @@
 
     & > span {
         flex-grow: 1;
+    }
+
+    .common-dropdown-button:focus-visible,
+    .common-dropdown-item:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        outline-offset: -3px;
     }
 }
 
@@ -143,6 +156,12 @@
     }
 }
 
+#waveform-select .common-radio-choice {
+    input:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+    }
+}
+
 /****************************************************
  *                     Preview                      *
  ****************************************************/
@@ -170,7 +189,7 @@
     background-color: var(--pxt-neutral-foreground2);
     color: var(--pxt-neutral-background2);
     position: absolute;
-    right: 0;
+    right: 5px;
     margin-top: -1.5rem;
 
     .fas.fa-play, .fas.fa-stop {
@@ -183,8 +202,9 @@
     }
 }
 
-.common-button.sound-effect-play-button:focus::after {
-    border-radius: 2rem;
+.common-button.sound-effect-play-button:focus-visible {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: 3px;
 }
 
 .sound-preview-baseline {
@@ -227,8 +247,14 @@
 
 .sound-gallery-scroller > .common-button {
     margin-bottom: 0.5rem;
-    padding: 0.6rem 1rem 0.6rem;
+    padding: 0.3rem 1rem 0.3rem 0.5rem;
+
+    &:focus-visible {
+        outline: 5px solid var(--pxt-focus-border);
+        outline-offset: -7px;
+    }
 }
+
 
 .sound-gallery-item-label {
     display: flex;
@@ -240,6 +266,15 @@
         margin-top: 0;
         z-index: 2;
     }
+}
+
+.sound-gallery-item-label-inner {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-grow: 1;
+    margin-right: 0.5rem;
+    padding: 0.3rem 0 0.3rem 0.5rem;
 
     .sound-effect-name {
         font-size: 22px;

--- a/theme/soundeffecteditor.less
+++ b/theme/soundeffecteditor.less
@@ -37,6 +37,11 @@
     flex-grow: 1;
     position: relative;
     overflow: hidden;
+
+    .common-dropdown-item:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        outline-offset: -3px;
+    }
 }
 
 .sound-controls {

--- a/webapp/src/BlocklyKeyboardIntercept.tsx
+++ b/webapp/src/BlocklyKeyboardIntercept.tsx
@@ -1,0 +1,55 @@
+import * as Blockly from 'blockly';
+import { useEffect, useRef } from "react"
+
+interface BlocklyKeyboardInterceptProps {
+    keyCodes: number[];
+    children: React.ReactNode;
+}
+
+const SHORTCUT_NAME = "temporary_makecode_key_suspensions";
+
+/**
+ * Top-level Blockly handlers for escape and enter interfere with standard 
+ * keyboard controls for navigating dropdowns. This temporarily suspends
+ * the effect when any of its children have focus.
+ */
+const suspendBlocklyKeyHandlers = (keyCodes: number[]) => {
+    const keyBlockHandler: Blockly.ShortcutRegistry.KeyboardShortcut = {
+        name: SHORTCUT_NAME,
+        allowCollision: true,
+        callback: () => true,
+        keyCodes,
+    };
+
+    Blockly.ShortcutRegistry.registry.register(keyBlockHandler);
+}
+
+const reinstateBlocklyKeyHandlers = () => {
+    Blockly.ShortcutRegistry.registry.unregister(SHORTCUT_NAME);
+}
+
+export const BlocklyKeyboardIntercept = ({children, keyCodes}: BlocklyKeyboardInterceptProps) => {
+    const keysSuspended = useRef<boolean>(false);
+
+    useEffect(() =>
+        () => { // when the component is destroyed, ensure it cleans up
+            if (keysSuspended.current) {
+                reinstateBlocklyKeyHandlers();
+            }
+        }, []);
+
+    return <div
+        onFocus={() => {
+            // Unlike pure HTML, React synthetic focus and blur bubble up from children
+            if (keysSuspended.current) return;
+            suspendBlocklyKeyHandlers(keyCodes);
+            keysSuspended.current = true;
+        }}
+        onBlur={() => {
+            if (!keysSuspended.current) return;
+            reinstateBlocklyKeyHandlers();
+            keysSuspended.current = false;
+        }}>
+        {children}
+    </div>
+}

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3395,15 +3395,15 @@ export class ProjectView
                         const res = await pxt.commands.showProgramTooLargeErrorAsync(attemptedVariants, core.confirmAsync, saveOnly);
                         if (res?.recompile) {
                             pxt.tickEvent("compile.programTooLargeDialog.recompile");
-                            const oldVariants = pxt.appTarget.multiVariants;
+                            const oldVariants = pxt.appTarget.disabledVariants;
                             this.setState({ compiling: false, isSaving: false });
                             try {
-                                pxt.appTarget.multiVariants = res.useVariants;
+                                pxt.appTarget.disabledVariants = pxt.appTarget.multiVariants.filter(v => !res.useVariants.includes(v));
                                 await this.compile(saveOnly);
                                 return;
                             }
                             finally {
-                                pxt.appTarget.multiVariants = oldVariants;
+                                pxt.appTarget.disabledVariants = oldVariants;
                             }
                         }
                         else {

--- a/webapp/src/blocklyFieldView.tsx
+++ b/webapp/src/blocklyFieldView.tsx
@@ -226,7 +226,7 @@ export function setContainerClass(className: string) {
 }
 
 export function init() {
-    pxt.react.getFieldEditorView = function<U>(fieldEditorId: string, value: U, options: any, container?: HTMLDivElement) {
+    pxt.react.getFieldEditorView = function<U>(fieldEditorId: string, value: U, options: any, container?: HTMLDivElement, keyboardTriggered?: boolean) {
         if (current) current.dispose();
 
         const refHandler = (e: FieldEditorComponent<any>) => {
@@ -260,7 +260,8 @@ export function init() {
                         }}
                         onSoundChange={options.onSoundChange}
                         initialSound={options.initialSound}
-                        useMixerSynthesizer={options.useMixerSynthesizer} />
+                        useMixerSynthesizer={options.useMixerSynthesizer}
+                        keyboardTriggered={keyboardTriggered} />
                 )
                 break;
             case "music-editor":

--- a/webapp/src/components/soundEffectEditor/SoundControls.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundControls.tsx
@@ -4,6 +4,7 @@ import { Dropdown, DropdownItem } from "../../../../react-common/components/cont
 import { RadioButtonGroup, RadioGroupChoice } from "../../../../react-common/components/controls/RadioButtonGroup";
 import { Input } from "../../../../react-common/components/controls/Input";
 import { DraggableGraph } from "../../../../react-common/components/controls/DraggableGraph";
+import { BlocklyKeyboardIntercept } from "../../BlocklyKeyboardIntercept";
 
 
 export interface SoundControlsProps {
@@ -198,26 +199,32 @@ export const SoundControls = (props: SoundControlsProps) => {
                     <div className="sound-label">
                         {pxt.U.lf("Duration (ms)")}
                     </div>
-                    <Input
-                        id="sound-duration-input"
-                        initialValue={sound.duration + ""}
-                        className="sound-duration-input"
-                        onEnterKey={onDurationChange}
-                        treatSpaceAsEnter={true}
-                        onBlur={onDurationChange}
-                        onOptionSelected={onOptionSelected}
-                        ariaLabel={pxt.U.lf("Duration (milliseconds)")}
-                        options={
-                            {
-                                [pxt.U.lf("100 ms")]: "100",
-                                [pxt.U.lf("200 ms")]: "200",
-                                [pxt.U.lf("500 ms")]: "500",
-                                [pxt.U.lf("1 second")]: "1000",
-                                [pxt.U.lf("2 seconds")]: "2000",
-                                [pxt.U.lf("5 seconds")]: "5000"
+                    <BlocklyKeyboardIntercept
+                    keyCodes={[
+                        13, /* Enter */
+                        27, /* Escape */
+                    ]}>
+                        <Input
+                            id="sound-duration-input"
+                            initialValue={sound.duration + ""}
+                            className="sound-duration-input"
+                            onEnterKey={onDurationChange}
+                            treatSpaceAsEnter={true}
+                            onBlur={onDurationChange}
+                            onOptionSelected={onOptionSelected}
+                            ariaLabel={pxt.U.lf("Duration (milliseconds)")}
+                            options={
+                                {
+                                    [pxt.U.lf("100 ms")]: "100",
+                                    [pxt.U.lf("200 ms")]: "200",
+                                    [pxt.U.lf("500 ms")]: "500",
+                                    [pxt.U.lf("1 second")]: "1000",
+                                    [pxt.U.lf("2 seconds")]: "2000",
+                                    [pxt.U.lf("5 seconds")]: "5000"
+                                }
                             }
-                        }
-                    />
+                        />
+                    </BlocklyKeyboardIntercept>
                 </div>
             </div>
         </div>

--- a/webapp/src/components/soundEffectEditor/SoundControls.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundControls.tsx
@@ -200,10 +200,11 @@ export const SoundControls = (props: SoundControlsProps) => {
                         {pxt.U.lf("Duration (ms)")}
                     </div>
                     <BlocklyKeyboardIntercept
-                    keyCodes={[
-                        13, /* Enter */
-                        27, /* Escape */
-                    ]}>
+                        keyCodes={[
+                            13, /* Enter */
+                            27, /* Escape */
+                        ]}
+                    >
                         <Input
                             id="sound-duration-input"
                             initialValue={sound.duration + ""}
@@ -238,31 +239,45 @@ export const SoundControls = (props: SoundControlsProps) => {
                         <span className="sound-label">
                             {pxt.U.lf("Effect")}
                         </span>
-
-                        <Dropdown
-                            id="effect-dropdown"
-                            className="icon-preview"
-                            selectedId={sound.effect}
-                            onItemSelected={onEffectSelected}
-                            items={effectOptions}
-                        />
+                        <BlocklyKeyboardIntercept
+                            keyCodes={[
+                                13, /* Enter */
+                                27, /* Escape */
+                            ]}
+                        >
+                            <Dropdown
+                                id="effect-dropdown"
+                                className="icon-preview"
+                                selectedId={sound.effect}
+                                onItemSelected={onEffectSelected}
+                                items={effectOptions}
+                            />
+                        </BlocklyKeyboardIntercept>
                     </div>
                     <div className="dropdown-and-label">
                         <span className="sound-label">
                             {pxt.U.lf("Interpolation")}
                         </span>
-                        <Dropdown
-                            id="interpolation-dropdown"
-                            className="icon-preview hang-left"
-                            selectedId={sound.interpolation}
-                            onItemSelected={onInterpolationSelected}
-                            items={interpolationOptions}
-                        />
+                        <BlocklyKeyboardIntercept
+                            keyCodes={[
+                                13, /* Enter */
+                                27, /* Escape */
+                            ]}
+                        >
+                            <Dropdown
+                                id="interpolation-dropdown"
+                                className="icon-preview hang-left"
+                                selectedId={sound.interpolation}
+                                onItemSelected={onInterpolationSelected}
+                                items={interpolationOptions}
+                            />
+                        </BlocklyKeyboardIntercept>
                     </div>
                 </div>
                 <DraggableGraph
                     min={1}
                     max={pxt.assets.MAX_FREQUENCY}
+                    ariaLabel={lf("Frequency over time")}
                     aspectRatio={3}
                     valueUnits={pxt.U.lf("Hz")}
                     points={[sound.startFrequency, sound.endFrequency]}
@@ -281,12 +296,13 @@ export const SoundControls = (props: SoundControlsProps) => {
                 <DraggableGraph
                     min={0}
                     max={pxt.assets.MAX_VOLUME}
+                    ariaLabel={lf("Volume over time")}
                     aspectRatio={5}
                     points={[sound.startVolume, sound.endVolume]}
                     interpolation="linear"
                     onPointChange={onVolumeChange}
                     handleStartAnimationRef={handleVolumeAnimationRef}
-                    squiggly={sound.effect === "tremolo"}
+                    squiggly={sound.effect === "tremolo" || sound.effect === "warble"}
                 />
             </div>
         </div>

--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Button } from "../../../../react-common/components/controls/Button";
-import { classList, fireClickOnEnter } from "../../../../react-common/components/util";
+import { classList } from "../../../../react-common/components/util";
 import { CancellationToken } from "./SoundEffectEditor";
 import { soundToCodalSound } from "./soundUtil";
 
@@ -18,33 +18,104 @@ export interface SoundGalleryProps {
 
 interface SoundGalleryItemProps extends SoundGalleryItem {
     useMixerSynthesizer: boolean;
+    selectReference: (el: HTMLDivElement) => void;
+    playReference: (el: HTMLButtonElement) => void;
+    previewKeyDown: (evt: React.KeyboardEvent<HTMLElement>) => void;
+    selectKeyDown: (evt: React.KeyboardEvent<HTMLElement>) => void;
 }
+
+type GalleryItem = Record<string, HTMLElement>;
 
 export const SoundGallery = (props: SoundGalleryProps) => {
     const { sounds, onSoundSelected, visible, useMixerSynthesizer } = props;
 
-    return <div className={classList("sound-gallery", visible && "visible")} aria-hidden={!visible}>
-        <div className="sound-gallery-scroller">
-            {sounds.map((item, index) =>
-                <div
-                    key={index}
-                    className="common-button"
-                    title={item.name}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={fireClickOnEnter}
-                    onClick={() => onSoundSelected(item.sound)}>
+    const selectItemRefs = React.useRef<[GalleryItem]>([{}]);
+    const playItemRefs = React.useRef<[GalleryItem]>([{}]);
+    const selectedCoord = React.useRef<{row: number, col: "select" | "preview"}>({row: 0, col: "select"});
 
-                    <SoundGalleryEntry {...item} useMixerSynthesizer={useMixerSynthesizer} />
-                </div>
-            )}
+    const focusSelectOrPlayElement = React.useCallback((e: React.KeyboardEvent<HTMLElement> | React.FocusEvent) => {
+        (selectedCoord.current.col === "select" ? selectItemRefs : playItemRefs).current[0][selectedCoord.current.row].focus();
+        e.preventDefault();
+    }, []);
+
+    const handleKeyDown = (
+        prev: number,
+        next: number,
+        current: number,
+        e: React.KeyboardEvent<HTMLElement>) => {
+        switch(e.code) {
+            case "ArrowDown":
+                selectedCoord.current.row = next;
+                break;
+            case "ArrowUp":
+                selectedCoord.current.row = prev;
+                break;
+            case "ArrowLeft":
+                selectedCoord.current.col = "select";
+                break;
+            case "ArrowRight":
+                selectedCoord.current.col = "preview";
+                break;
+            case "Space":
+            case "Enter":
+                if (selectedCoord.current.col === "select") {
+                    onSoundSelected(sounds[current].sound)
+                    e.stopPropagation();
+                    e.preventDefault();
+                }
+                return;
+            case "Home":
+                selectedCoord.current = {col: "select", row: 0};
+                break;
+            case "End":
+                selectedCoord.current = {col: "preview", row: sounds.length - 1};
+                break;
+            default: {
+                return;
+            }
+        }
+        focusSelectOrPlayElement(e);
+    }
+
+    return <div className={classList("sound-gallery", visible && "visible")} aria-hidden={!visible}>
+        <div className="sound-gallery-scroller"
+            tabIndex={0}
+            onFocus={focusSelectOrPlayElement}>
+            {sounds.map((item, index) => {
+                    const prev = Math.max(index - 1, 0);
+                    const next = Math.min(index + 1, sounds.length - 1);
+                    return(<div
+                        key={index}
+                        onClick={() => onSoundSelected(item.sound)}
+                        className="common-button">
+
+                        <SoundGalleryEntry
+                            {...item}
+                            useMixerSynthesizer={useMixerSynthesizer}
+
+                            selectReference={ref => selectItemRefs.current[0][index] = ref}
+                            playReference={ref => playItemRefs.current[0][index] = ref}
+
+                            previewKeyDown={evt => handleKeyDown(prev, next, index, evt)}
+                            selectKeyDown={evt => handleKeyDown(prev, next, index, evt)}
+                        />
+                    </div>);
+                })
+            }
         </div>
     </div>
 }
 
-
 const SoundGalleryEntry = (props: SoundGalleryItemProps) => {
-    const { sound, name, useMixerSynthesizer } = props;
+    const {
+        sound,
+        name,
+        useMixerSynthesizer,
+        playReference,
+        selectReference,
+        previewKeyDown,
+        selectKeyDown
+    } = props;
     const width = 160;
     const height = 40;
 
@@ -72,22 +143,32 @@ const SoundGalleryEntry = (props: SoundGalleryItemProps) => {
     }
 
     return <div className="sound-gallery-item-label">
-        <div className="sound-effect-name">
-            {name}
-        </div>
-        <div className="sound-gallery-preview">
-            <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
-                <path
-                    className="sound-gallery-preview-wave"
-                    d={pxt.assets.renderSoundPath(sound, width, height)}
-                    strokeWidth="2"
-                    fill="none"/>
-            </svg>
+        <div className="sound-gallery-item-label-inner"
+            tabIndex={-1}
+            ref={selectReference}
+            onKeyDown={selectKeyDown}
+            title={name}
+            role="button">
+            <div className="sound-effect-name">
+                {name}
+            </div>
+            <div className="sound-gallery-preview">
+                <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        className="sound-gallery-preview-wave"
+                        d={pxt.assets.renderSoundPath(sound, width, height)}
+                        strokeWidth="2"
+                        fill="none"/>
+                </svg>
+            </div>
         </div>
         <Button
             className="sound-effect-play-button"
+            buttonRef={playReference}
+            tabIndex={-1}
             title={cancelToken ? lf("Stop Sound Preview") : lf("Preview Sound")}
             onClick={handlePlayButtonClick}
+            onKeydown={previewKeyDown}
             leftIcon={cancelToken ? "fas fa-stop" : "fas fa-play"}
             />
     </div>

--- a/webapp/src/monacoSnippets.ts
+++ b/webapp/src/monacoSnippets.ts
@@ -662,7 +662,7 @@ function cachedBuiltinCategories(): pxt.Map<BuiltinCategoryDefinition> {
                     snippet: `"".substr(0, 0)`,
                     pySnippet: `""[0:1]`,
                     attributes: {
-                        blockId: 'string_substr',
+                        blockId: 'string_substr_new',
                         jsDoc: lf("Returns the part of a string starting at a given index with the given length")
                     },
                     retType: "string"


### PR DESCRIPTION
[https://soundeffect-editor-accessibi.review-pxt.pages.dev](https://soundeffect-editor-accessibi.review-pxt.pages.dev/)

### Summary

Overall accessibility improvements for keyboard navigation including visual feedback. Changes include
* Navigating the gallery in a Grid pattern [as recommended by WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)
* Improved combo box behaviour
* Highlighting the selected waveform is now more visible
* Keeps the cursor in a focus trap inside the Sound Effect editor until escape is pressed or the window is otherwise closed
* Keyboard controls for the frequency and volume sliders
* Fixed the browser console error relating to Radio Groups

Note that this changes the Selected Waveform Radio Group for all users. This is because other recent theming changes have reduced the contrast between the active button and other radio buttons, and this makes it strongly visible again. Ie.:

**In master**

<img width="163" alt="image" src="https://github.com/user-attachments/assets/0665bce1-366c-4185-86ba-a8a2bdfc9267" />

**In this branch**

<img width="173" alt="image" src="https://github.com/user-attachments/assets/4e18c6ec-7bf6-4056-9870-ac45c2e65ad0" />

### Walkthrough video using tab, arrow keys, space, enter, escape

https://github.com/user-attachments/assets/0d04efb9-a86d-49ea-90ef-a3efe8d791bc

### To test

1. Go to the Live demo above
2. Create a project containing a Sound Effect
3. Enable Accessible Blocks in the cog menu 
4. Navigate to the Sound Effect using the arrow keys and press enter
5. Explore the UI