### PR TITLE
Add navigate regions overlay and keyboard shortcut

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -717,6 +717,7 @@ declare namespace pxt.editor {
         resize(): void;
         setScale(scale: number): void;
         focusWorkspace(): void;
+        focusToolbox(): void;
     }
 
     export interface IFile {
@@ -820,6 +821,7 @@ declare namespace pxt.editor {
         extensionsVisible?: boolean;
         isMultiplayerGame?: boolean; // Arcade: Does the current project contain multiplayer blocks?
         onboarding?: pxt.tour.BubbleStep[];
+        navigateRegions?: boolean;
         feedback?: FeedbackState;
         themePickerOpen?: boolean;
     }
@@ -1057,6 +1059,8 @@ declare namespace pxt.editor {
         hideLightbox(): void;
         showOnboarding(): void;
         hideOnboarding(): void;
+        showNavigateRegions(): void;
+        hideNavigateRegions(): void;
         showKeymap(show: boolean): void;
         toggleKeymap(): void;
         signOutGithub(): void;

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -19,6 +19,9 @@ namespace pxsim.accessibility {
         } else if (e.key === "d" && meta) {
             e.preventDefault();
             return "webUSBDownload"
+        } else if (e.key === "j" && meta) {
+            e.preventDefault();
+            return "navigateRegions"
         }
         return null
     }

--- a/pxtsim/accessibility.ts
+++ b/pxtsim/accessibility.ts
@@ -10,13 +10,7 @@ namespace pxsim.accessibility {
 
     export function getKeyboardShortcutEditorAction(e: KeyboardEvent): pxsim.SimulatorActionMessage["type"] | null {
         const meta  = e.metaKey || e.ctrlKey;
-        if (e.key === "e" && meta) {
-            e.preventDefault();
-            return "focusWorkspace"
-        } else if (e.key === "b" && meta) {
-            e.preventDefault();
-            return "focusSimulator"
-        } else if (e.key === "d" && meta) {
+        if (e.key === "d" && meta) {
             e.preventDefault();
             return "webUSBDownload"
         } else if (e.key === "j" && meta) {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -76,7 +76,7 @@ namespace pxsim {
     }
 
     export interface SimulatorActionMessage extends SimulatorMessage {
-        type: "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "webUSBDownload" | "navigateRegions";
+        type: "toggleShortcutDoc" | "webUSBDownload" | "navigateRegions";
     }
 
     export interface SimulatorStateMessage extends SimulatorMessage {

--- a/pxtsim/embed.ts
+++ b/pxtsim/embed.ts
@@ -76,7 +76,7 @@ namespace pxsim {
     }
 
     export interface SimulatorActionMessage extends SimulatorMessage {
-        type: "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "webUSBDownload";
+        type: "toggleShortcutDoc" | "focusWorkspace" | "focusSimulator" | "webUSBDownload" | "navigateRegions";
     }
 
     export interface SimulatorStateMessage extends SimulatorMessage {

--- a/theme/navigateregions.less
+++ b/theme/navigateregions.less
@@ -47,11 +47,21 @@
             margin: auto;
             padding-right: 1em;
             padding-left: 1em;
-            border-radius: 5px
+            border-radius: 5px;
+
+            @media only screen and (max-width: @largestMobileScreen) {
+                padding-right: 0.5em;
+                padding-left: 0.5em;
+            }
         }
         p {
             color: white;
             font-size: 2rem;
+
+            @media only screen and (max-width: @largestTabletScreen), 
+            only screen and (max-height: @tallEditorBreakpoint) and (min-width: @largestMobileScreen) {
+                font-size: 1.5rem;
+            }
         }
     }
 }

--- a/theme/navigateregions.less
+++ b/theme/navigateregions.less
@@ -23,7 +23,7 @@
         border: 3px solid white;
         padding: 0;
 
-        &.mini-sim-region {
+        &.simulator-region {
             z-index: 1;
         }
 

--- a/theme/navigateregions.less
+++ b/theme/navigateregions.less
@@ -1,0 +1,57 @@
+/* Import all components */
+@import 'themes/default/globals/site.variables';
+@import 'themes/pxt/globals/site.variables';
+
+/* Reference import */
+@import (reference) "semantic.less";
+
+.navigate-regions-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0);
+    width: 100%;
+    height: 100%;
+    z-index: @modalDimmerZIndex;
+
+    .region-button {
+        position: absolute;
+        background-color: rgba(0, 0, 0, .6);
+        border-radius: 0;
+        border: 3px solid white;
+        padding: 0;
+
+        &.mini-sim-region {
+            z-index: 1;
+        }
+
+        &:focus-visible {
+            background-color: rgba(0, 0, 0, .3);
+
+            div {
+                border: 5px solid white;
+                background-color: black;
+            }
+
+            p {
+                font-weight: bold;
+            }
+        }
+
+        div {
+            background-color: rgba(0, 0, 0, .6);
+            border: 2px solid white;
+            width: fit-content;
+            margin: auto;
+            padding-right: 1em;
+            padding-left: 1em;
+            border-radius: 5px
+        }
+        p {
+            color: white;
+            font-size: 2rem;
+        }
+    }
+}

--- a/theme/pxt.less
+++ b/theme/pxt.less
@@ -32,6 +32,7 @@
 @import 'accessibility';
 @import 'highcontrast';
 @import 'greenscreen';
+@import 'navigateregions';
 
 @import 'extension';
 @import 'extensionErrors';

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -80,6 +80,7 @@ import Util = pxt.Util;
 import { HintManager } from "./hinttooltip";
 import { mergeProjectCode, appendTemporaryAssets } from "./mergeProjects";
 import { Tour } from "./components/onboarding/Tour";
+import { NavigateRegionsOverlay } from "./components/NavigateRegionsOverlay";
 import { parseTourStepsAsync } from "./onboarding";
 import { initGitHubDb } from "./idbworkspace";
 import { BlockDefinition, CategoryNameID } from "./toolbox";
@@ -220,6 +221,7 @@ export class ProjectView
         this.hwDebug = this.hwDebug.bind(this);
         this.hideLightbox = this.hideLightbox.bind(this);
         this.hideOnboarding = this.hideOnboarding.bind(this);
+        this.hideNavigateRegions = this.hideNavigateRegions.bind(this);
         this.hideFeedback = this.hideFeedback.bind(this);
         this.openSimSerial = this.openSimSerial.bind(this);
         this.openDeviceSerial = this.openDeviceSerial.bind(this);
@@ -5248,6 +5250,18 @@ export class ProjectView
     }
 
     ///////////////////////////////////////////////////////////
+    ////////////             Navigate regions     /////////////
+    ///////////////////////////////////////////////////////////
+
+    hideNavigateRegions() {
+        this.setState({ navigateRegions: false });
+    }
+
+    showNavigateRegions() {
+        this.setState({ navigateRegions: true })
+    }
+
+    ///////////////////////////////////////////////////////////
     ////////////             Key map              /////////////
     ///////////////////////////////////////////////////////////
 
@@ -5507,6 +5521,7 @@ export class ProjectView
                 {lightbox ? <sui.Dimmer isOpen={true} active={lightbox} portalClassName={'tutorial'} className={'ui modal'}
                     shouldFocusAfterRender={false} closable={true} onClose={this.hideLightbox} /> : undefined}
                 {this.state.onboarding && <Tour tourSteps={this.state.onboarding} onClose={this.hideOnboarding} />}
+                {accessibleBlocks && this.state.navigateRegions && <NavigateRegionsOverlay parent={this} onClose={this.hideNavigateRegions}/>}
                 {this.state.themePickerOpen && <ThemePickerModal themes={this.themeManager.getAllColorThemes()} onThemeClicked={theme => this.setColorThemeById(theme?.id, true)} onClose={this.hideThemePicker} />}
             </div>
         );

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -616,6 +616,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                         })();
                         return
                     }
+                    case "navigateRegions" : {
+                        this.parent.showNavigateRegions();
+                        return
+                    }
                 }
             }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -590,15 +590,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             const triggerEditorAction = (action: pxsim.SimulatorActionMessage["type"]) => {
                 switch (action) {
-                    case "focusWorkspace": {
-                        this.parent.editor.focusWorkspace();
-                        return
-                    }
-                    case "focusSimulator": {
-                        // Note that pxtsim.driver.focus() isn't the same as tabbing to the sim.
-                        (document.querySelector("#boardview") as HTMLElement).focus();
-                        return
-                    }
                     case "webUSBDownload": {
                         (async () => {
                             // TODO: refactor and share with editortoolbar.tsx

--- a/webapp/src/components/NavigateRegionsOverlay.tsx
+++ b/webapp/src/components/NavigateRegionsOverlay.tsx
@@ -19,14 +19,14 @@ interface RectBounds {
     height: number;
 }
 
-type Region = "topbar" | "simulator" | "toolbox" | "workspace" | "bottombar"
+type Region = "mainmenu" | "simulator" | "toolbox" | "workspace" | "editortools"
 
 const shortcutToRegion: Record<string, Region> = {
-    "1": "topbar",
+    "1": "mainmenu",
     "2": "simulator",
     "3": "toolbox",
     "4": "workspace",
-    "5": "bottombar"
+    "5": "editortools"
 }
 
 const regionToShortcut = Object.entries(shortcutToRegion).reduce((acc, entry) => {
@@ -45,14 +45,14 @@ export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverl
             ).getBoundingClientRect(),
         toolbox: document.querySelector(".blocklyToolbox").getBoundingClientRect(),
         workspace: document.querySelector(".blocklySvg").getBoundingClientRect(),
-        topbar: document.querySelector("#mainmenu").getBoundingClientRect(),
-        bottombar: document.querySelector("#editortools").getBoundingClientRect(),
+        mainmenu: document.querySelector("#mainmenu").getBoundingClientRect(),
+        editortools: document.querySelector("#editortools").getBoundingClientRect(),
     })
     const [regionRects, setRegionRects] = useState(getRects())
 
     const focusRegion = useCallback((region: Region) => {
         switch (region) {
-            case "topbar": {
+            case "mainmenu": {
                 (document.querySelector(".blocks-menuitem") as HTMLElement).focus();
                 onClose();
                 return
@@ -73,7 +73,7 @@ export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverl
                 onClose();
                 return
             }
-            case "bottombar": {
+            case "editortools": {
                 ((!!document.querySelector(".miniSim")
                     ? document.querySelector(".download-button-full")
                     : document.querySelector(".download-button.large")) as HTMLElement).focus();
@@ -112,9 +112,9 @@ export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverl
     return ReactDOM.createPortal(<FocusTrap dontRestoreFocus onEscape={handleEscape}>
         <div className="navigate-regions-container">
             <RegionButton
-                title={regionToShortcut["topbar"]}
-                bounds={regionRects.topbar}
-                onClick={() => focusRegion("topbar")}
+                title={regionToShortcut["mainmenu"]}
+                bounds={regionRects.mainmenu}
+                onClick={() => focusRegion("mainmenu")}
                 ariaLabel={lf("Main menu")}
             />
             <RegionButton
@@ -144,10 +144,10 @@ export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverl
                 ariaLabel={lf("Workspace")}
             />
             <RegionButton
-                title={regionToShortcut["bottombar"]}
-                bounds={regionRects.bottombar}
-                onClick={() => focusRegion("bottombar")}
-                ariaLabel={lf("Project menu")}
+                title={regionToShortcut["editortools"]}
+                bounds={regionRects.editortools}
+                onClick={() => focusRegion("editortools")}
+                ariaLabel={lf("Editor toolbar")}
             />
         </div>
     </FocusTrap>, document.getElementById("root") || document.body)

--- a/webapp/src/components/NavigateRegionsOverlay.tsx
+++ b/webapp/src/components/NavigateRegionsOverlay.tsx
@@ -118,7 +118,7 @@ export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverl
                 ariaLabel={lf("Main menu")}
             />
             <RegionButton
-                className={!!document.querySelector(".miniSim") && "mini-sim-region"}
+                className="simulator-region"
                 title={regionToShortcut["simulator"]}
                 bounds={regionRects.simulator}
                 onClick={() => focusRegion("simulator")}

--- a/webapp/src/components/NavigateRegionsOverlay.tsx
+++ b/webapp/src/components/NavigateRegionsOverlay.tsx
@@ -36,6 +36,7 @@ const regionToShortcut = Object.entries(shortcutToRegion).reduce((acc, entry) =>
   }, {} as Record<Region, string>);
 
 export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverlayProps) => {
+    const previouslyFocused = useRef<Element>(document.activeElement);
     const getRects = () => ({
         simulator: (
             !!document.querySelector(".miniSim")
@@ -101,7 +102,14 @@ export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverl
         }
     }, [])
 
-    return ReactDOM.createPortal(<FocusTrap dontRestoreFocus onEscape={onClose}>
+    const handleEscape = () => {
+        if (previouslyFocused.current) {
+            (previouslyFocused.current as HTMLElement).focus()
+        }
+        onClose();
+    }
+
+    return ReactDOM.createPortal(<FocusTrap dontRestoreFocus onEscape={handleEscape}>
         <div className="navigate-regions-container">
             <RegionButton
                 title={regionToShortcut["topbar"]}

--- a/webapp/src/components/NavigateRegionsOverlay.tsx
+++ b/webapp/src/components/NavigateRegionsOverlay.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as ReactDOM from "react-dom";
+import { Button, ButtonProps } from "../../../react-common/components/controls/Button";
+import { FocusTrap } from "../../../react-common/components/controls/FocusTrap";
+
+import IProjectView = pxt.editor.IProjectView;
+
+interface NavigateRegionsOverlayProps {
+    parent: IProjectView;
+    onClose: () => void;
+}
+
+interface RectBounds {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+    width: number;
+    height: number;
+}
+
+type Region = "topbar" | "simulator" | "toolbox" | "workspace" | "bottombar"
+
+const shortcutToRegion: Record<string, Region> = {
+    "1": "topbar",
+    "2": "simulator",
+    "3": "toolbox",
+    "4": "workspace",
+    "5": "bottombar"
+}
+
+const regionToShortcut = Object.entries(shortcutToRegion).reduce((acc, entry) => {
+    const [shortcut, region] = entry;
+    acc[region] = shortcut;
+    return acc;
+  }, {} as Record<Region, string>);
+
+export const NavigateRegionsOverlay = ({ parent, onClose }: NavigateRegionsOverlayProps) => {
+    const getRects = () => ({
+        simulator: (
+            !!document.querySelector(".miniSim")
+                ? document.querySelector(".simPanel")
+                : document.querySelector("#editorSidebar")
+            ).getBoundingClientRect(),
+        toolbox: document.querySelector(".blocklyToolbox").getBoundingClientRect(),
+        workspace: document.querySelector(".blocklySvg").getBoundingClientRect(),
+        topbar: document.querySelector("#mainmenu").getBoundingClientRect(),
+        bottombar: document.querySelector("#editortools").getBoundingClientRect(),
+    })
+    const [regionRects, setRegionRects] = useState(getRects())
+
+    const focusRegion = useCallback((region: Region) => {
+        switch (region) {
+            case "topbar": {
+                (document.querySelector(".blocks-menuitem") as HTMLElement).focus();
+                onClose();
+                return
+            }
+            case "simulator": {
+                // Note that pxtsim.driver.focus() isn't the same as tabbing to the sim.
+                (document.querySelector("#boardview") as HTMLElement).focus();
+                onClose()
+                return
+            }
+            case "workspace": {
+                parent.editor.focusWorkspace();
+                onClose();
+                return
+            }
+            case "toolbox": {
+                parent.editor.focusToolbox();
+                onClose();
+                return
+            }
+            case "bottombar": {
+                ((!!document.querySelector(".miniSim")
+                    ? document.querySelector(".download-button-full")
+                    : document.querySelector(".download-button.large")) as HTMLElement).focus();
+                onClose();
+                return
+            }
+        }
+    }, [])
+
+    useEffect(() => {
+        const listener = (e: KeyboardEvent) => {
+            const region = shortcutToRegion[e.key]
+            focusRegion(region)
+        }
+        document.addEventListener("keydown", listener)
+
+        const observer = new ResizeObserver(() => {
+            setRegionRects(getRects())
+        });
+
+        observer.observe(document.body);
+
+        return () => {
+            observer.disconnect()
+            document.removeEventListener("keydown", listener)
+        }
+    }, [])
+
+    return ReactDOM.createPortal(<FocusTrap dontRestoreFocus onEscape={onClose}>
+        <div className="navigate-regions-container">
+            <RegionButton
+                title={regionToShortcut["topbar"]}
+                bounds={regionRects.topbar}
+                onClick={() => focusRegion("topbar")}
+                ariaLabel={lf("Main menu")}
+            />
+            <RegionButton
+                className={!!document.querySelector(".miniSim") && "mini-sim-region"}
+                title={regionToShortcut["simulator"]}
+                bounds={regionRects.simulator}
+                onClick={() => focusRegion("simulator")}
+                ariaLabel={lf("Simulator")}
+            />
+            <RegionButton
+                title={regionToShortcut["toolbox"]}
+                bounds={regionRects.toolbox}
+                onClick={() => focusRegion("toolbox")}
+                ariaLabel={lf("Toolbox")}
+            />
+            <RegionButton
+                title={regionToShortcut["workspace"]}
+                bounds={{
+                    right: regionRects.workspace.right,
+                    bottom: regionRects.workspace.bottom,
+                    top: regionRects.workspace.top,
+                    height: regionRects.workspace.height,
+                    left: regionRects.toolbox.right,
+                    width: regionRects.workspace.width - regionRects.toolbox.width
+                }}
+                onClick={() => focusRegion("workspace")}
+                ariaLabel={lf("Workspace")}
+            />
+            <RegionButton
+                title={regionToShortcut["bottombar"]}
+                bounds={regionRects.bottombar}
+                onClick={() => focusRegion("bottombar")}
+                ariaLabel={lf("Project menu")}
+            />
+        </div>
+    </FocusTrap>, document.getElementById("root") || document.body)
+}
+
+interface RegionButtonProps extends ButtonProps {
+    bounds: RectBounds
+}
+
+const RegionButton = ({bounds, ...props}: RegionButtonProps) => {
+    const buttonRef = useRef<HTMLButtonElement>()
+
+    useEffect(() => {
+        if (bounds) {
+            buttonRef.current.style.top = `${bounds.top}px`;
+            buttonRef.current.style.height = `${bounds.height}px`;
+            buttonRef.current.style.left = `${bounds.left}px`;
+            buttonRef.current.style.width = `${bounds.width}px`;
+        }
+    }, [bounds])
+
+    return <Button
+        buttonRef={(ref) => {buttonRef.current = ref}}
+        {...props}
+        className={`region-button ${props.className}`}
+    >
+        <div><p>{props.title}</p></div>
+    </Button>
+}


### PR DESCRIPTION
**Todo**
- [ ] When editor is not in blocks mode, the navigate region should work
- [ ] Indicate simulator when it is collapsed

**Next steps outside of PR**
- Update keyboard-nav-docs to have updated keyboard shortcuts
