### PR TITLE
Correct background color for field

### DIFF
--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -247,6 +247,7 @@ text.blocklyCheckbox {
     .blocklyNonEditableText > rect.blocklySpriteField,
     .blocklyNonEditableText > rect.blocklyAnimationField,
     .blocklyNonEditableText > rect.blocklyTilemapField,
+    .blocklyEditableField > rect.blocklySpriteField,
     .blocklyEditableText > rect.blocklySpriteField,
     .blocklyEditableText > rect.blocklyAnimationField,
     .blocklyEditableText > rect.blocklyTilemapField {


### PR DESCRIPTION
[Task](https://github.com/microbit-foundation/blockly-project/issues/230) (Private)

Not sure if the intention is for it to be merged into blockly-12 so have kept it as draft.

After screenshot:
<img width="624" alt="Screenshot 2025-05-20 at 15 26 47" src="https://github.com/user-attachments/assets/debe5f21-7c5f-47fd-bbc5-bb04c1f34de3" />
