### PR TITLE
Enable cross-tab cut, copy, paste while using the keyboard nav plugin

### DIFF
--- a/pxtblocks/copyPaste.ts
+++ b/pxtblocks/copyPaste.ts
@@ -30,7 +30,7 @@ export function initCopyPaste(accessibleBlocksEnabled: boolean) {
     }
 }
 
-export function initAccessibleContextMenu() {
+export function initAccessibleBlocksCopyPasteContextMenu() {
     overridePasteContextMenuItem();
     overrideCutContextMenuItem();
 }

--- a/pxtblocks/copyPaste.ts
+++ b/pxtblocks/copyPaste.ts
@@ -7,7 +7,7 @@ let oldCopy: Blockly.ShortcutRegistry.KeyboardShortcut;
 let oldCut: Blockly.ShortcutRegistry.KeyboardShortcut;
 let oldPaste: Blockly.ShortcutRegistry.KeyboardShortcut;
 
-export function initCopyPaste() {
+export function initCopyPaste(accessibleBlocksEnabled: boolean) {
     if (oldCopy || !getCopyPasteHandlers()) return;
 
     const shortcuts = Blockly.ShortcutRegistry.registry.getRegistry()
@@ -23,8 +23,73 @@ export function initCopyPaste() {
     registerCopy();
     registerCut();
     registerPaste();
-    registerCopyContextMenu();
-    registerPasteContextMenu();
+
+    if (!accessibleBlocksEnabled) {
+        registerCopyContextMenu();
+        registerPasteContextMenu();
+    }
+}
+
+export function initAccessibleContextMenu() {
+    overridePasteContextMenuItem();
+    overrideCutContextMenuItem();
+}
+
+function overridePasteContextMenuItem() {
+    const oldPasteOption = Blockly.ContextMenuRegistry.registry.getItem("blockPasteFromContextMenu");
+
+    if ("separator" in oldPasteOption) {
+        throw new Error(`RegistryItem ${oldPasteOption.id} is not of type ActionRegistryItem`);
+    };
+
+    const pasteOption: Blockly.ContextMenuRegistry.RegistryItem = {
+        ...oldPasteOption,
+        preconditionFn: pasteContextMenuPreconditionFn,
+    };
+
+    Blockly.ContextMenuRegistry.registry.unregister("blockPasteFromContextMenu");
+    Blockly.ContextMenuRegistry.registry.register(pasteOption);
+}
+
+function overrideCutContextMenuItem() {
+    const oldCutOption = Blockly.ContextMenuRegistry.registry.getItem("blockCutFromContextMenu");
+
+    if ("separator" in oldCutOption) {
+        throw new Error(`RegistryItem ${oldCutOption.id} is not of type ActionRegistryItem`);
+    };
+
+    const cutOption: Blockly.ContextMenuRegistry.RegistryItem = {
+        ...oldCutOption,
+        preconditionFn: (scope: Blockly.ContextMenuRegistry.Scope) => {
+            const focused = scope.focusedNode;
+            if (!focused || !Blockly.isCopyable(focused)) return "hidden";
+
+            const workspace = focused.workspace;
+
+            if (focused.workspace.isFlyout)
+                return "hidden";
+
+            if (
+                workspace.isReadOnly() &&
+                (Blockly.isDeletable(focused) &&
+                !focused.isDeletable()) ||
+                (Blockly.isDraggable(focused) &&
+                !focused.isMovable())
+            )
+                return "disabled";
+
+            const handlers = getCopyPasteHandlers();
+
+            if (handlers) {
+                return handlers.copyPrecondition(scope);
+            }
+
+            return "enabled";
+        },
+    };
+
+    Blockly.ContextMenuRegistry.registry.unregister("blockCutFromContextMenu");
+    Blockly.ContextMenuRegistry.registry.register(cutOption);
 }
 
 function registerCopy() {
@@ -49,7 +114,7 @@ function registerCut() {
             const handler = getCopyPasteHandlers()?.cut;
 
             if (handler) {
-                return handler(workspace, e);
+                return handler(workspace, e, shortcut, scope);
             }
 
             return oldCut.callback(workspace, e, shortcut, scope);
@@ -96,7 +161,7 @@ function registerCopyContextMenu() {
             if (!block) return;
 
             block.select();
-            copy(block.workspace, e);
+            copy(block.workspace, e, undefined, scope);
         },
         scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
         weight: BlockContextWeight.Copy,
@@ -125,7 +190,7 @@ function registerCopyContextMenu() {
             if (!comment) return;
 
             comment.select();
-            copy(comment.workspace, e);
+            copy(comment.workspace, e, undefined, scope);
         },
         scopeType: Blockly.ContextMenuRegistry.ScopeType.COMMENT,
         weight: BlockContextWeight.Copy,
@@ -139,24 +204,12 @@ function registerCopyContextMenu() {
 function registerPasteContextMenu() {
     const pasteOption: Blockly.ContextMenuRegistry.RegistryItem = {
         displayText: () => lf("Paste"),
-        preconditionFn: (scope: Blockly.ContextMenuRegistry.Scope) => {
-            if (pxt.shell.isReadOnly() || scope.workspace.options.readOnly) {
-                return "hidden";
-            }
-
-            const handlers = getCopyPasteHandlers();
-
-            if (handlers) {
-                return handlers.pastePrecondition(scope);
-            }
-
-            return "enabled";
-        },
+        preconditionFn: pasteContextMenuPreconditionFn,
         callback: function (scope: Blockly.ContextMenuRegistry.Scope, e: PointerEvent): void {
             const workspace = scope.workspace;
 
             if (!workspace) return;
-            paste(workspace, e);
+            paste(workspace, e, undefined, scope);
         },
         scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
         weight: WorkspaceContextWeight.Paste,
@@ -166,11 +219,25 @@ function registerPasteContextMenu() {
     Blockly.ContextMenuRegistry.registry.register(pasteOption);
 }
 
+const pasteContextMenuPreconditionFn = (scope: Blockly.ContextMenuRegistry.Scope) => {
+    if (pxt.shell.isReadOnly() || scope.workspace?.options.readOnly) {
+        return "hidden";
+    }
+
+    const handlers = getCopyPasteHandlers();
+
+    if (handlers) {
+        return handlers.pastePrecondition(scope);
+    }
+
+    return "enabled";
+}
+
 const copy = (workspace: Blockly.WorkspaceSvg, e: Event, shortcut?: Blockly.ShortcutRegistry.KeyboardShortcut, scope?: Blockly.ContextMenuRegistry.Scope) => {
     const handler = getCopyPasteHandlers()?.copy;
 
     if (handler) {
-        return handler(workspace, e);
+        return handler(workspace, e, shortcut, scope);
     }
 
     return oldCopy.callback(workspace, e, shortcut, scope);
@@ -180,7 +247,7 @@ const paste = (workspace: Blockly.WorkspaceSvg, e: Event, shortcut?: Blockly.Sho
     const handler = getCopyPasteHandlers()?.paste;
 
     if (handler) {
-        return handler(workspace, e);
+        return handler(workspace, e, shortcut, scope);
     }
 
     return oldPaste.callback(workspace, e, shortcut, scope);

--- a/pxtblocks/external.ts
+++ b/pxtblocks/external.ts
@@ -90,7 +90,7 @@ export function openWorkspaceSearch() {
     }
 }
 
-type ShortcutHandler = (workspace: Blockly.Workspace, e: Event) => boolean;
+type ShortcutHandler = (workspace: Blockly.Workspace, e: Event, shortcut: Blockly.ShortcutRegistry.KeyboardShortcut, scope: Blockly.ContextMenuRegistry.Scope) => boolean;
 type PreconditionFn = (scope: Blockly.ContextMenuRegistry.Scope) => "enabled" | "disabled" | "hidden";
 
 let _handleCopy: ShortcutHandler;

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -25,6 +25,7 @@ import { renderCodeCard } from "./codecardRenderer";
 import { FieldDropdown } from "./fields/field_dropdown";
 import { setDraggableShadowBlocks, setDuplicateOnDrag, setDuplicateOnDragStrategy } from "./plugins/duplicateOnDrag";
 import { initAccessibleBlocksCopyPasteContextMenu, initCopyPaste } from "./copyPaste";
+export { initCopyPaste } from "./copyPaste";
 import { FieldVariable } from "./plugins/newVariableField/fieldVariable";
 import { ArgumentReporterBlock, FieldArgumentReporter, setArgumentReporterLocalizeFunction } from "./plugins/functions";
 import { getArgumentReporterParent } from "./plugins/functions/utils";
@@ -586,7 +587,8 @@ export function cleanBlocks() {
  * Used by pxtrunner to initialize blocks in the docs
  */
 export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
-    init(blockInfo, false);
+    init(blockInfo);
+    initCopyPaste(false);
     injectBlocks(blockInfo);
 }
 
@@ -594,13 +596,13 @@ export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
  * Used by main app to initialize blockly blocks.
  * Blocks are injected separately by called injectBlocks
  */
-export function initialize(blockInfo: pxtc.BlocksInfo, accessibleBlocksEnabled: boolean) {
-    init(blockInfo, accessibleBlocksEnabled);
+export function initialize(blockInfo: pxtc.BlocksInfo) {
+    init(blockInfo);
     initJresIcons(blockInfo);
 }
 
 let blocklyInitialized = false;
-function init(blockInfo: pxtc.BlocksInfo, accessibleBlocksEnabled: boolean) {
+function init(blockInfo: pxtc.BlocksInfo) {
     if (blocklyInitialized) return;
     blocklyInitialized = true;
 
@@ -616,7 +618,6 @@ function init(blockInfo: pxtc.BlocksInfo, accessibleBlocksEnabled: boolean) {
     initText();
     initComments();
     initTooltip();
-    initCopyPaste(accessibleBlocksEnabled);
 }
 
 export function initAccessibleBlocksContextMenuItems() {

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -24,7 +24,7 @@ import { initContextMenu } from "./contextMenu";
 import { renderCodeCard } from "./codecardRenderer";
 import { FieldDropdown } from "./fields/field_dropdown";
 import { setDraggableShadowBlocks, setDuplicateOnDrag, setDuplicateOnDragStrategy } from "./plugins/duplicateOnDrag";
-import { initAccessibleContextMenu, initCopyPaste } from "./copyPaste";
+import { initAccessibleBlocksCopyPasteContextMenu, initCopyPaste } from "./copyPaste";
 import { FieldVariable } from "./plugins/newVariableField/fieldVariable";
 import { ArgumentReporterBlock, FieldArgumentReporter, setArgumentReporterLocalizeFunction } from "./plugins/functions";
 import { getArgumentReporterParent } from "./plugins/functions/utils";
@@ -619,11 +619,8 @@ function init(blockInfo: pxtc.BlocksInfo, accessibleBlocksEnabled: boolean) {
     initCopyPaste(accessibleBlocksEnabled);
 }
 
-let accessibleContextMenuInitialized = false;
 export function initAccessibleBlocksContextMenuItems() {
-    if (accessibleContextMenuInitialized) return;
-    accessibleContextMenuInitialized = true;
-    initAccessibleContextMenu()
+    initAccessibleBlocksCopyPasteContextMenu()
 }
 
 

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -24,7 +24,7 @@ import { initContextMenu } from "./contextMenu";
 import { renderCodeCard } from "./codecardRenderer";
 import { FieldDropdown } from "./fields/field_dropdown";
 import { setDraggableShadowBlocks, setDuplicateOnDrag, setDuplicateOnDragStrategy } from "./plugins/duplicateOnDrag";
-import { initCopyPaste } from "./copyPaste";
+import { initAccessibleContextMenu, initCopyPaste } from "./copyPaste";
 import { FieldVariable } from "./plugins/newVariableField/fieldVariable";
 import { ArgumentReporterBlock, FieldArgumentReporter, setArgumentReporterLocalizeFunction } from "./plugins/functions";
 import { getArgumentReporterParent } from "./plugins/functions/utils";
@@ -586,7 +586,7 @@ export function cleanBlocks() {
  * Used by pxtrunner to initialize blocks in the docs
  */
 export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
-    init(blockInfo);
+    init(blockInfo, false);
     injectBlocks(blockInfo);
 }
 
@@ -594,13 +594,13 @@ export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
  * Used by main app to initialize blockly blocks.
  * Blocks are injected separately by called injectBlocks
  */
-export function initialize(blockInfo: pxtc.BlocksInfo) {
-    init(blockInfo);
+export function initialize(blockInfo: pxtc.BlocksInfo, accessibleBlocksEnabled: boolean) {
+    init(blockInfo, accessibleBlocksEnabled);
     initJresIcons(blockInfo);
 }
 
 let blocklyInitialized = false;
-function init(blockInfo: pxtc.BlocksInfo) {
+function init(blockInfo: pxtc.BlocksInfo, accessibleBlocksEnabled: boolean) {
     if (blocklyInitialized) return;
     blocklyInitialized = true;
 
@@ -616,7 +616,14 @@ function init(blockInfo: pxtc.BlocksInfo) {
     initText();
     initComments();
     initTooltip();
-    initCopyPaste();
+    initCopyPaste(accessibleBlocksEnabled);
+}
+
+let accessibleContextMenuInitialized = false;
+export function initAccessibleBlocksContextMenuItems() {
+    if (accessibleContextMenuInitialized) return;
+    accessibleContextMenuInitialized = true;
+    initAccessibleContextMenu()
 }
 
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -241,21 +241,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
                     // Initialize blocks in Blockly and update our toolbox
                     pxtblockly.initialize(this.blockInfo, accessibleBlocksEnabled);
-                    this.nsMap = this.partitionBlocks();
-                    this.refreshToolbox();
-
                     // This must come after pxtblockly.initialize which overrides the default cut, copy,
                     // paste shortcuts. The keyboard navigation plugin utilizes these cut, copy and paste
                     // shortcuts and wraps them with additional behaviours (e.g., toast notifications).
-                    this.initAccessibleBlocks(accessibleBlocksEnabled);
-
                     if (accessibleBlocksEnabled) {
-                        // This must come after this.initAccessibleBlocks to override context menu
-                        // precondition functions set by the keyboard navigation plugin.
-                        // We want to customize this behavior and have access to clipboard data to
-                        // determined whether paste should be enabled.
-                        pxtblockly.initAccessibleBlocksContextMenuItems();
+                        this.initAccessibleBlocks();
                     }
+
+                    this.nsMap = this.partitionBlocks();
+                    this.refreshToolbox();
 
                     pxt.debug(`loading block workspace`)
                     let xml = this.delayLoadXml;
@@ -592,8 +586,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         };
     }
 
-    private initAccessibleBlocks(enabled: boolean) {
-        if (enabled && !this.keyboardNavigation) {
+    private initAccessibleBlocks() {
+        if (!this.keyboardNavigation) {
             this.keyboardNavigation = new KeyboardNavigation(this.editor);
 
             const listShortcuts = Blockly.ShortcutRegistry.registry.getRegistry()["list_shortcuts"];
@@ -621,6 +615,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     return true
                 }
             });
+
+            // This must come after plugin initialization to override context menu
+            // precondition functions set by the keyboard navigation plugin.
+            // We want to customize this behavior and have access to clipboard data to
+            // determined whether paste should be enabled.
+            pxtblockly.initAccessibleBlocksContextMenuItems();
         }
     }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2521,7 +2521,7 @@ function copy(workspace: Blockly.WorkspaceSvg, e: Event, _shortcut: Blockly.Shor
 
 // adapted from Blockly/core/shortcut_items.ts
 function cut(workspace: Blockly.WorkspaceSvg, _e: Event, _shortcut: Blockly.ShortcutRegistry.KeyboardShortcut, scope: Blockly.ContextMenuRegistry.Scope) {
-      const focused = scope.focusedNode;
+    const focused = scope.focusedNode;
 
     if (focused instanceof Blockly.BlockSvg) {
         const copyData = focused.toCopyData();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -38,7 +38,7 @@ import SimState = pxt.editor.SimState;
 import { DuplicateOnDragConnectionChecker } from "../../pxtblocks/plugins/duplicateOnDrag";
 import { PathObject } from "../../pxtblocks/plugins/renderer/pathObject";
 import { Measurements } from "./constants";
-import { flow } from "../../pxtblocks";
+import { flow, initCopyPaste } from "../../pxtblocks";
 import { HIDDEN_CLASS_NAME } from "../../pxtblocks/plugins/flyout/blockInflater";
 import { AIFooter } from "../../react-common/components/controls/AIFooter";
 
@@ -237,16 +237,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 .then(bi => {
                     this.blockInfo = bi;
 
-                    const accessibleBlocksEnabled = data.getData<boolean>(auth.ACCESSIBLE_BLOCKS)
-
                     // Initialize blocks in Blockly and update our toolbox
-                    pxtblockly.initialize(this.blockInfo, accessibleBlocksEnabled);
-                    // This must come after pxtblockly.initialize which overrides the default cut, copy,
-                    // paste shortcuts. The keyboard navigation plugin utilizes these cut, copy and paste
-                    // shortcuts and wraps them with additional behaviours (e.g., toast notifications).
-                    if (accessibleBlocksEnabled) {
-                        this.initAccessibleBlocks();
-                    }
+                    pxtblockly.initialize(this.blockInfo);
 
                     this.nsMap = this.partitionBlocks();
                     this.refreshToolbox();
@@ -816,6 +808,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.initPrompts();
         this.initBlocklyToolbox();
         this.initWorkspaceSounds();
+        const accessibleBlocksEnabled = data.getData<boolean>(auth.ACCESSIBLE_BLOCKS)
+        initCopyPaste(accessibleBlocksEnabled);
+        // This must come after initCopyPaste which overrides the default cut, copy,
+        // paste shortcuts. The keyboard navigation plugin utilizes these cut, copy and paste
+        // shortcuts and wraps them with additional behaviours (e.g., toast notifications).
+        if (accessibleBlocksEnabled) {
+            this.initAccessibleBlocks();
+        }
         this.initWorkspaceSearch();
         this.setupIntersectionObserver();
         this.resize();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -237,10 +237,25 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 .then(bi => {
                     this.blockInfo = bi;
 
+                    const accessibleBlocksEnabled = data.getData<boolean>(auth.ACCESSIBLE_BLOCKS)
+
                     // Initialize blocks in Blockly and update our toolbox
-                    pxtblockly.initialize(this.blockInfo);
+                    pxtblockly.initialize(this.blockInfo, accessibleBlocksEnabled);
                     this.nsMap = this.partitionBlocks();
                     this.refreshToolbox();
+
+                    // This must come after pxtblockly.initialize which overrides the default cut, copy,
+                    // paste shortcuts. The keyboard navigation plugin utilizes these cut, copy and paste
+                    // shortcuts and wraps them with additional behaviours (e.g., toast notifications).
+                    this.initAccessibleBlocks(accessibleBlocksEnabled);
+
+                    if (accessibleBlocksEnabled) {
+                        // This must come after this.initAccessibleBlocks to override context menu
+                        // precondition functions set by the keyboard navigation plugin.
+                        // We want to customize this behavior and have access to clipboard data to
+                        // determined whether paste should be enabled.
+                        pxtblockly.initAccessibleBlocksContextMenuItems();
+                    }
 
                     pxt.debug(`loading block workspace`)
                     let xml = this.delayLoadXml;
@@ -500,10 +515,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             pxtblockly.external.setPromptTranslateBlock(dialogs.promptTranslateBlock);
         }
 
-        // Disable clipboard overwrite (initCopyPaste) when accessible blocks enabled.
-        if (!data.getData<boolean>(auth.ACCESSIBLE_BLOCKS)) {
-            pxtblockly.external.setCopyPaste(copy, cut, this.pasteCallback, this.copyPrecondition, this.pastePrecondition);
-        }
+        pxtblockly.external.setCopyPaste(copy, cut, this.pasteCallback, this.copyPrecondition, this.pastePrecondition);
     }
 
     private initBlocklyToolbox() {
@@ -580,8 +592,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         };
     }
 
-    private initAccessibleBlocks() {
-        const enabled = data.getData<boolean>(auth.ACCESSIBLE_BLOCKS)
+    private initAccessibleBlocks(enabled: boolean) {
         if (enabled && !this.keyboardNavigation) {
             this.keyboardNavigation = new KeyboardNavigation(this.editor);
 
@@ -805,7 +816,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.initPrompts();
         this.initBlocklyToolbox();
         this.initWorkspaceSounds();
-        this.initAccessibleBlocks();
         this.initWorkspaceSearch();
         this.setupIntersectionObserver();
         this.resize();
@@ -2356,7 +2366,12 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     protected pastePrecondition = (scope: Blockly.ContextMenuRegistry.Scope) => {
-        if (scope.workspace !== this.editor) return "hidden";
+        if (
+            (scope.workspace && scope.workspace !== this.editor) ||
+            (scope.block && scope.block.workspace !== this.editor)
+        )
+            return "hidden";
+
 
         const data = getCopyData();
 
@@ -2475,21 +2490,21 @@ function resolveLocalizedMarkdown(url: string) {
 }
 
 // adapted from Blockly/core/shortcut_items.ts
-function copy(workspace: Blockly.WorkspaceSvg, e: Event) {
+function copy(workspace: Blockly.WorkspaceSvg, e: Event, _shortcut: Blockly.ShortcutRegistry.KeyboardShortcut, scope: Blockly.ContextMenuRegistry.Scope) {
     // Prevent the default copy behavior, which may beep or otherwise indicate
     // an error due to the lack of a selection.
     e.preventDefault();
     workspace.hideChaff();
-    const selected = Blockly.common.getSelected();
-    if (!selected || !Blockly.isCopyable(selected)) return false;
+    const focused = scope.focusedNode;
+    if (!focused || !Blockly.isCopyable(focused)) return false;
+    const copyData = focused.toCopyData();
 
-    const copyData = selected.toCopyData();
     const copyWorkspace =
-        selected.workspace instanceof Blockly.WorkspaceSvg
-            ? selected.workspace
+        focused.workspace instanceof Blockly.WorkspaceSvg
+            ? focused.workspace
             : workspace;
-    const copyCoords = Blockly.isDraggable(selected)
-        ? selected.getRelativeToSurfaceXY()
+    const copyCoords = Blockly.isDraggable(focused)
+        ? focused.getRelativeToSurfaceXY()
         : null;
 
     if (copyData) {
@@ -2505,30 +2520,30 @@ function copy(workspace: Blockly.WorkspaceSvg, e: Event) {
 }
 
 // adapted from Blockly/core/shortcut_items.ts
-function cut(workspace: Blockly.WorkspaceSvg, e: Event) {
-    const selected = Blockly.common.getSelected();
+function cut(workspace: Blockly.WorkspaceSvg, _e: Event, _shortcut: Blockly.ShortcutRegistry.KeyboardShortcut, scope: Blockly.ContextMenuRegistry.Scope) {
+      const focused = scope.focusedNode;
 
-    if (selected instanceof Blockly.BlockSvg) {
-        const copyData = selected.toCopyData();
+    if (focused instanceof Blockly.BlockSvg) {
+        const copyData = focused.toCopyData();
         const copyWorkspace = workspace;
-        const copyCoords = selected.getRelativeToSurfaceXY();
+        const copyCoords = focused.getRelativeToSurfaceXY();
         saveCopyData(
             copyData,
             copyCoords,
             copyWorkspace,
             pkg.mainEditorPkg().header.id
         );
-        selected.checkAndDelete();
+        focused.checkAndDelete();
         return true;
     } else if (
-        Blockly.isDeletable(selected) &&
-        selected.isDeletable() &&
-        Blockly.isCopyable(selected)
+        Blockly.isDeletable(focused) &&
+        focused.isDeletable() &&
+        Blockly.isCopyable(focused)
     ) {
-        const copyData = selected.toCopyData();
+        const copyData = focused.toCopyData();
         const copyWorkspace = workspace;
-        const copyCoords = Blockly.isDraggable(selected)
-            ? selected.getRelativeToSurfaceXY()
+        const copyCoords = Blockly.isDraggable(focused)
+            ? focused.getRelativeToSurfaceXY()
             : null;
         saveCopyData(
             copyData,
@@ -2536,7 +2551,7 @@ function cut(workspace: Blockly.WorkspaceSvg, e: Event) {
             copyWorkspace,
             pkg.mainEditorPkg().header.id
         );
-        selected.dispose();
+        focused.dispose();
         return true;
     }
     return false;


### PR DESCRIPTION
We've got a mixture of different approaches in precondition checks now, maybe these should be aligned.