### PR TITLE
Upgrade to Blockly v12.1.0 and Blockly keyboard navigation v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@blockly/field-colour": "6.0.0",
-    "@blockly/keyboard-navigation": "1.0.0-beta.0",
+    "@blockly/keyboard-navigation": "1.0.0",
     "@blockly/plugin-workspace-search": "10.0.0",
     "@crowdin/crowdin-api-client": "^1.33.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
@@ -72,7 +72,7 @@
     "@zip.js/zip.js": "2.4.20",
     "adm-zip": "^0.5.12",
     "axios": "^1.6.8",
-    "blockly": "12.1.0-beta.0",
+    "blockly": "12.1.0",
     "browserify": "17.0.0",
     "chai": "^3.5.0",
     "chalk": "^4.1.2",
@@ -159,10 +159,10 @@
       "source-map": "0.4.4"
     },
     "@blockly/field-colour": {
-      "blockly": "^12.1.0-beta.0"
+      "blockly": "^12.1.0"
     },
     "@blockly/plugin-workspace-search": {
-      "blockly": "^12.1.0-beta.0"
+      "blockly": "^12.1.0"
     }
   },
   "scripts": {

--- a/pxtblocks/builtins/variables.ts
+++ b/pxtblocks/builtins/variables.ts
@@ -240,6 +240,8 @@ function flyoutCategory(workspace: Blockly.WorkspaceSvg, useXml: boolean): Eleme
     const button = document.createElement('button') as HTMLElement;
     button.setAttribute('text', lf("Make a Variable..."));
     button.setAttribute('callbackKey', 'CREATE_VARIABLE');
+    // This id is used to re-focus the create variable button after the dialog is closed.
+    button.setAttribute('id', 'create-variable-btn');
 
     workspace.registerButtonCallback('CREATE_VARIABLE', function (button) {
         Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());

--- a/pxtblocks/builtins/variables.ts
+++ b/pxtblocks/builtins/variables.ts
@@ -2,6 +2,8 @@ import * as Blockly from "blockly";
 import { createFlyoutGroupLabel, createFlyoutHeadingLabel, mkVariableFieldBlock } from "../toolbox";
 import { installBuiltinHelpInfo, setBuiltinHelpInfo } from "../help";
 
+export const CREATE_VAR_BTN_ID = 'create-variable-btn';
+
 export function initVariables() {
     let varname = lf("{id:var}item");
     Blockly.Variables.flyoutCategory = flyoutCategory;
@@ -241,7 +243,7 @@ function flyoutCategory(workspace: Blockly.WorkspaceSvg, useXml: boolean): Eleme
     button.setAttribute('text', lf("Make a Variable..."));
     button.setAttribute('callbackKey', 'CREATE_VARIABLE');
     // This id is used to re-focus the create variable button after the dialog is closed.
-    button.setAttribute('id', 'create-variable-btn');
+    button.setAttribute('id', CREATE_VAR_BTN_ID);
 
     workspace.registerButtonCallback('CREATE_VARIABLE', function (button) {
         Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace());

--- a/pxtblocks/copyPaste.ts
+++ b/pxtblocks/copyPaste.ts
@@ -128,8 +128,13 @@ function registerCut() {
 function registerPaste() {
     const pasteShortcut: Blockly.ShortcutRegistry.KeyboardShortcut = {
         name: Blockly.ShortcutItems.names.PASTE,
-        preconditionFn(workspace, scope) {
-            return oldPaste.preconditionFn(workspace, scope);
+        preconditionFn(workspace, _scope) {
+            // Override the paste precondition in core as it now checks
+            // it's own clipboard for copy data.
+            return (
+                !workspace.isReadOnly() &&
+                !workspace.isDragging()
+            );
         },
         callback: paste,
         keyCodes: oldPaste.keyCodes,

--- a/pxtblocks/copyPaste.ts
+++ b/pxtblocks/copyPaste.ts
@@ -133,7 +133,8 @@ function registerPaste() {
             // it's own clipboard for copy data.
             return (
                 !workspace.isReadOnly() &&
-                !workspace.isDragging()
+                !workspace.isDragging() &&
+                !Blockly.getFocusManager().ephemeralFocusTaken()
             );
         },
         callback: paste,

--- a/pxtblocks/plugins/flyout/buttonFlyoutInflater.ts
+++ b/pxtblocks/plugins/flyout/buttonFlyoutInflater.ts
@@ -14,12 +14,17 @@ export class ButtonFlyoutInflater extends Blockly.ButtonFlyoutInflater {
     }
 
     load(state: object, flyout: Blockly.IFlyout): Blockly.FlyoutItem {
+        const modifiedState = state as Blockly.utils.toolbox.ButtonOrLabelInfo & {id?: string};
         const button = new FlyoutButton(
             flyout.getWorkspace(),
             flyout.targetWorkspace!,
-            state as Blockly.utils.toolbox.ButtonOrLabelInfo,
+            modifiedState,
             false,
         );
+        if (modifiedState.id) {
+            // This id is used to manage focus after dialog interactions.
+            button.getSvgRoot().setAttribute("id", modifiedState.id)
+        }
         button.show();
 
         return new Blockly.FlyoutItem(button, BUTTON_TYPE);

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -757,8 +757,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             if (ev.type === "var_create") {
                 if (this.currentFlyoutKey === "variables" && this.editor.getFlyout()?.isVisible()) {
+                    const focusManager = Blockly.getFocusManager();
+                    const createVarButtonNode = focusManager.getFocusedNode();
+                    const createVarButtonElement = createVarButtonNode.getFocusableElement();
+
                     // refresh the flyout when a new variable is created
                     this.showVariablesFlyout();
+
+                    if (createVarButtonElement && createVarButtonNode.canBeFocused()) {
+                        const flyoutWorkspace = this.editor.getFlyout().getWorkspace();
+                        const newCreateVarButtonNode = flyoutWorkspace.lookUpFocusableNode(createVarButtonElement.id);
+                        const flyout = this.editor.getFlyout();
+                        const flyoutCursor = flyout.getWorkspace().getCursor();
+                        flyoutCursor.setCurNode(newCreateVarButtonNode);
+                    } else {
+                        this.focusWorkspace();
+                    }
                 }
             }
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2514,6 +2514,15 @@ function copy(workspace: Blockly.WorkspaceSvg, e: Event, _shortcut: Blockly.Shor
     e.preventDefault();
     workspace.hideChaff();
     const focused = scope.focusedNode;
+
+    // If copying a block in the flyout via the context menu, the workspace is the flyout,
+    // otherwise (using the keyboard shortcut) the workspace is the main workspace.
+    // If the workspace is the main workspace, calling hideChaff will close the flyout,
+    // so focus the main workspace after that happens.
+    if ((focused as Blockly.BlockSvg).isInFlyout && !workspace.isFlyout) {
+        Blockly.getFocusManager().focusTree(workspace);
+    }
+
     if (!focused || !Blockly.isCopyable(focused)) return false;
     const copyData = focused.toCopyData();
 

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -569,7 +569,14 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         (Blockly.WorkspaceSvg as any).prototype.getRestoredFocusableNode = function (previousNode: Blockly.IFocusableNode | null) {
             // Specifically handle flyout case to work with the caching flyout implementation
             if (this.isFlyout) {
-                return that.getDefaultFlyoutCursorIfNeeded(that.editor.getFlyout());
+                const flyout = that.editor.getFlyout()
+                const node = that.getDefaultFlyoutCursorIfNeeded(flyout);
+                if (node) {
+                    const flyoutCursor = flyout.getWorkspace().getCursor();
+                    // Work around issue with a flyout label being the first item in the flyout.
+                    flyoutCursor.setCurNode(node);
+                }
+                return node;
             }
             // Default implementation
             if (!previousNode) {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -41,6 +41,7 @@ import { Measurements } from "./constants";
 import { flow, initCopyPaste } from "../../pxtblocks";
 import { HIDDEN_CLASS_NAME } from "../../pxtblocks/plugins/flyout/blockInflater";
 import { AIFooter } from "../../react-common/components/controls/AIFooter";
+import { CREATE_VAR_BTN_ID } from "../../pxtblocks/builtins/variables";
 
 interface CopyDataEntry {
     version: 1;
@@ -757,10 +758,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
 
             if (ev.type === "var_create") {
                 if (this.currentFlyoutKey === "variables" && this.editor.getFlyout()?.isVisible()) {
-                    const focusManager = Blockly.getFocusManager();
-                    const createVarButtonNode = focusManager.getFocusedNode();
-                    const createVarButtonElement = createVarButtonNode.getFocusableElement();
-
                     // Prevents toolbox selection from clearing when creating a variable via keyboard
                     // inside workspace onTreeBlur.
                     this.setFlyoutForceOpen(true);
@@ -769,10 +766,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     // Workspace onTreeBlur is not called if the var is created via mouse, so reset state.
                     this.setFlyoutForceOpen(false);
 
-                    if (createVarButtonElement && createVarButtonNode.canBeFocused()) {
-                        const flyoutWorkspace = this.editor.getFlyout().getWorkspace();
-                        const newCreateVarButtonNode = flyoutWorkspace.lookUpFocusableNode(createVarButtonElement.id);
-                        const flyout = this.editor.getFlyout();
+                    const flyout = this.editor.getFlyout();
+                    const flyoutWorkspace = flyout.getWorkspace();
+                    const newCreateVarButtonNode = flyoutWorkspace.lookUpFocusableNode(CREATE_VAR_BTN_ID);
+                    if (newCreateVarButtonNode) {
                         const flyoutCursor = flyout.getWorkspace().getCursor();
                         flyoutCursor.setCurNode(newCreateVarButtonNode);
                     } else {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -761,8 +761,13 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     const createVarButtonNode = focusManager.getFocusedNode();
                     const createVarButtonElement = createVarButtonNode.getFocusableElement();
 
+                    // Prevents toolbox selection from clearing when creating a variable via keyboard
+                    // inside workspace onTreeBlur.
+                    this.setFlyoutForceOpen(true);
                     // refresh the flyout when a new variable is created
                     this.showVariablesFlyout();
+                    // Workspace onTreeBlur is not called if the var is created via mouse, so reset state.
+                    this.setFlyoutForceOpen(false);
 
                     if (createVarButtonElement && createVarButtonNode.canBeFocused()) {
                         const flyoutWorkspace = this.editor.getFlyout().getWorkspace();


### PR DESCRIPTION
Features:
- Adds ability to copy blocks from the flyout

Fixes:
- A navigation issue in the flyout after tabbing from the toolbox where the cursor would get stuck or was missing
- Re-focuses the "Make a Variable..." button after creating a variable via mouse or keyboard
- Opening the context menu in the flyout no longer closes the flyout
- Keyboard shortcuts are ignored while ephemeral focus is taken. This prevents navigation of blocks in the background while a dropdown is open.
- Moving a block via keyboard when focus is on input no longer causes the input to be passively focused