### PR TITLE
Enable breakpoint icons to be toggled via keyboard

### DIFF
--- a/pxtblocks/breakpointIcon.ts
+++ b/pxtblocks/breakpointIcon.ts
@@ -23,9 +23,7 @@ export class BreakpointIcon extends Blockly.icons.Icon {
         this.breakpointSvg = Blockly.utils.dom.createSvgElement(
             'circle',
             {
-                'class': 'blocklyBreakpointSymbol',
-                'stroke': 'white',
-                'stroke-width': 2,
+                'class': 'blocklyIconShape blocklyBreakpointSymbol',
                 'cx': 7,
                 'cy': 11.5,
                 'r': 8,
@@ -59,6 +57,21 @@ export class BreakpointIcon extends Blockly.icons.Icon {
     protected updateColor() {
         if (!this.breakpointSvg) return;
 
-        this.breakpointSvg.setAttribute("fill", this.isSet_ ? "#FF0000" : "#CCCCCC")
+        if (this.isSet_) {
+            this.breakpointSvg.classList.add('active');
+        } else {
+            this.breakpointSvg.classList.remove('active');
+        }
     }
 }
+
+Blockly.Css.register(`
+    .blocklyIconShape.blocklyBreakpointSymbol {
+        stroke-width: 2px;
+        stroke: white;
+        fill: #CCCCCC;
+    }
+    .blocklyIconShape.blocklyBreakpointSymbol.active {
+        fill: #FF0000;
+    }
+`);

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -422,10 +422,7 @@ div.blocklyTreeRoot > div[role="tree"]:focus-visible {
 > .blocklyFieldRect,
 .blocklyKeyboardNavigation
 .blocklyActiveFocus.blocklyField
-> .blocklyFieldRect.blocklySpriteField,
-.blocklyKeyboardNavigation
-.blocklyActiveFocus.blocklyIconGroup
-> .blocklyIconShape:first-child {
+> .blocklyFieldRect.blocklySpriteField {
     stroke: var(--blockly-active-node-color);
     stroke-width: var(--blockly-selection-width);
 }
@@ -441,10 +438,7 @@ div.blocklyTreeRoot > div[role="tree"]:focus-visible {
 > .blocklyFieldRect,
 .blocklyKeyboardNavigation
 .blocklyPassiveFocus.blocklyField
-> .blocklyFieldRect.blocklySpriteField,
-.blocklyKeyboardNavigation
-.blocklyPassiveFocus.blocklyIconGroup
-> .blocklyIconShape:first-child {
+> .blocklyFieldRect.blocklySpriteField {
     stroke: var(--blockly-active-node-color);
     stroke-dasharray: 5px 3px;
     stroke-width: var(--blockly-selection-width);
@@ -468,6 +462,26 @@ div.blocklyTreeRoot > div[role="tree"]:focus-visible {
     outline-offset: calc(var(--blockly-selection-width) * -1);
     outline: var(--blockly-selection-width) solid
         var(--blockly-active-tree-color);
+}
+
+/* Icons */
+.blocklyKeyboardNavigation
+.blocklyActiveFocus.blocklyIconGroup {
+    opacity: 1;
+    > .blocklyIconShape:first-child {
+        border-radius: 2px;
+        outline: var(--blockly-selection-width) solid
+        var(--blockly-active-node-color);
+        outline-offset: 2px;
+    }
+}
+.blocklyKeyboardNavigation
+.blocklyPassiveFocus.blocklyIconGroup
+> .blocklyIconShape:first-child {
+    outline-offset:  2px;
+    outline: var(--blockly-selection-width) dashed
+    var(--blockly-active-node-color);
+    border-radius: 2px;
 }
 
 /* Flyout buttons and labels */

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -627,7 +627,8 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             this.keyboardNavigation = new KeyboardNavigation(this.editor);
             Blockly.keyboardNavigationController.setIsActive(true);
 
-            const listShortcuts = Blockly.ShortcutRegistry.registry.getRegistry()["list_shortcuts"];
+            const shortcuts = Blockly.ShortcutRegistry.registry.getRegistry();
+            const listShortcuts = shortcuts["list_shortcuts"];
             Blockly.ShortcutRegistry.registry.unregister(listShortcuts.name);
             Blockly.ShortcutRegistry.registry.register({
                 ...listShortcuts,
@@ -641,7 +642,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 ]
             });
 
-            const cleanUpWorkspace = Blockly.ShortcutRegistry.registry.getRegistry()["clean_up_workspace"];
+            const cleanUpWorkspace = shortcuts["clean_up_workspace"];
             Blockly.ShortcutRegistry.registry.unregister(cleanUpWorkspace.name);
             Blockly.ShortcutRegistry.registry.register({
                 ...cleanUpWorkspace,
@@ -651,6 +652,22 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     flow(workspace, { useViewWidth: true });
                     return true
                 }
+            });
+
+            const editOrConfirm = shortcuts['edit_or_confirm'];
+            Blockly.ShortcutRegistry.registry.unregister(editOrConfirm.name);
+            Blockly.ShortcutRegistry.registry.register({
+                ...editOrConfirm,
+                preconditionFn(workspace, scope) {
+                    // If the cursor is on an icon, allow interaction, even in readonly mode.
+                    const cursor = workspace.getCursor();
+                    const curNode = cursor?.getCurNode();
+                    if (curNode && curNode instanceof Blockly.icons.Icon) {
+                        return true;
+                    }
+                    return editOrConfirm.preconditionFn(workspace, scope);
+                },
+                allowCollision: true,
             });
 
             // This must come after plugin initialization to override context menu

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -662,7 +662,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     // If the cursor is on an icon, allow interaction, even in readonly mode.
                     const cursor = workspace.getCursor();
                     const curNode = cursor?.getCurNode();
-                    if (curNode && curNode instanceof Blockly.icons.Icon) {
+                    const accessibilityMode = workspace.isFlyout
+                        ? workspace.targetWorkspace?.keyboardAccessibilityMode
+                        : workspace.keyboardAccessibilityMode;
+                    if (
+                        curNode &&
+                        curNode instanceof Blockly.icons.Icon &&
+                        !!accessibilityMode &&
+                        !Blockly.getFocusManager().ephemeralFocusTaken()
+                    ) {
                         return true;
                     }
                     return editOrConfirm.preconditionFn(workspace, scope);


### PR DESCRIPTION
The current `editOrConfirm` shortcut in the plugin checks to see if the user [canCurrentlyEdit](https://github.com/google/blockly-keyboard-experimentation/blob/main/src/actions/enter.ts#L58) and returns false if the workspace is readonly. In current MakeCode, comments and breakpoints can be clicked on via the mouse in readonly mode, note that comments cannot be edited. This feels like a mistake in the plugin. 

This PR has a workaround by specially treating icons. In draft because it's not clear that this is the best way forward.

The CSS for icons when focused via keyboard has been updated.