### PR TITLE
Don't show prompt when editing a slider or text dropdown on mobile

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1345,8 +1345,9 @@ function uploadCoreAsync(opts: UploadOptions) {
 
     // check size
     const maxSize = checkFileSize(opts.fileList);
-    if (maxSize > 30000000) // 30Mb max
-        U.userError(`file too big for upload`);
+    const maxAllowedFileSize = (pxt.appTarget.cloud.maxFileSize || (30000000)); // default to 30Mb
+    if (maxSize > maxAllowedFileSize)
+        U.userError(`file too big for upload: ${maxSize} bytes, max is ${maxAllowedFileSize} bytes`);
     pxt.log('');
 
     if (opts.localDir)
@@ -6113,7 +6114,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
 
     const maxFileSize = checkFileSize(nodeutil.allFiles("docs", { maxDepth: 10, allowMissing: true, includeDirs: true, ignoredFileMarker: ".ignorelargefiles" }));
     if (!pxt.appTarget.ignoreDocsErrors
-        && maxFileSize > (pxt.appTarget.cloud.maxFileSize || (5000000)))
+        && maxFileSize > (pxt.appTarget.cloud.maxFileSize || (30000000)))
         U.userError(`files too big in docs folder`);
 
     // scan and fix image links

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -955,7 +955,7 @@ declare namespace pxt.editor {
         saveAndCompile(): void;
         updateHeaderName(name: string): void;
         updateHeaderNameAsync(name: string): Promise<void>;
-        compile(): void;
+        compile(saveOnly?: boolean): void;
 
         setFile(fn: IFile, line?: number): void;
         setSideFile(fn: IFile, line?: number): void;
@@ -1093,7 +1093,7 @@ declare namespace pxt.editor {
         showPackageDialog(query?: string): void;
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
-        pairAsync(): Promise<boolean>;
+        pairDialogAsync(): Promise<pxt.commands.WebUSBPairResult>;
 
         createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;

--- a/localtypings/pxtpackage.d.ts
+++ b/localtypings/pxtpackage.d.ts
@@ -33,6 +33,7 @@ declare namespace pxt {
      */
     interface PackageConfig {
         name: string;
+        displayName?: string; // used for the codecard in the extension dialog
         version?: string;
         // installedVersion?: string; moved to Package class
         // url to icon -- support for built-in packages only

--- a/pxtblocks/fields/field_textdropdown.ts
+++ b/pxtblocks/fields/field_textdropdown.ts
@@ -68,13 +68,21 @@ export class BaseFieldTextDropdown extends Blockly.FieldTextInput {
     }
 
     protected showEditor_(e?: Event, quietInput?: boolean): void {
-        super.showEditor_(e, quietInput);
+        // Align with Blockly's approach in https://github.com/google/blockly-samples/blob/master/plugins/field-slider/src/field_slider.ts
+        // Always quiet the input for the super constructor, as we don't want to
+        // focus on the text field, and we don't want to display the modal
+        // editor on mobile devices.
+        super.showEditor_(e, true);
 
         if (!this.dropDownOpen_) this.showDropdown_();
         Blockly.Touch.clearTouchIdentifier();
 
         this.inputKeydownHandler = this.inputKeydownListener.bind(this);
         this.htmlInput_.addEventListener('keydown', this.inputKeydownHandler);
+
+        if (!quietInput) {
+            this.htmlInput_.focus();
+        }
     }
 
     override doValueUpdate_(newValue: string) {

--- a/pxtblocks/plugins/comments/bubble.ts
+++ b/pxtblocks/plugins/comments/bubble.ts
@@ -53,6 +53,7 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
 
     private dragStrategy = new Blockly.dragging.BubbleDragStrategy(this, this.workspace);
 
+    private focusableElement: SVGElement | HTMLElement;
 
     private topBar: SVGRectElement;
 
@@ -76,6 +77,7 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
         public readonly workspace: Blockly.WorkspaceSvg,
         protected anchor: Blockly.utils.Coordinate,
         protected ownerRect?: Blockly.utils.Rect,
+        overriddenFocusableElement?: SVGElement | HTMLElement,
     ) {
         this.id = Blockly.utils.idGenerator.getNextUniqueId();
         this.svgRoot = dom.createSvgElement(
@@ -138,6 +140,9 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
             },
             embossGroup
         );
+
+        this.focusableElement = overriddenFocusableElement ?? this.svgRoot;
+        this.focusableElement.setAttribute('id', this.id);
 
         Blockly.browserEvents.conditionalBind(
             this.background,
@@ -267,6 +272,7 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
     private onMouseDown(e: PointerEvent) {
         this.workspace.getGesture(e)?.handleBubbleStart(e, this);
         Blockly.common.setSelected(this);
+        Blockly.getFocusManager().focusNode(this);
     }
 
     /** Positions the bubble relative to its anchor. Does not render its tail. */
@@ -633,15 +639,17 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
 
     select(): void {
         // Bubbles don't have any visual for being selected.
+        Blockly.common.fireSelectedEvent(this);
     }
 
     unselect(): void {
         // Bubbles don't have any visual for being selected.
+        Blockly.common.fireSelectedEvent(null);
     }
 
     /** See IFocusableNode.getFocusableElement. */
     getFocusableElement(): HTMLElement | SVGElement {
-      return this.svgRoot;
+        return this.focusableElement;
     }
 
     /** See IFocusableNode.getFocusableTree. */

--- a/pxtblocks/plugins/comments/textinput_bubble.ts
+++ b/pxtblocks/plugins/comments/textinput_bubble.ts
@@ -37,7 +37,7 @@ export class TextInputBubble extends Bubble {
     /** Functions listening for changes to the size of this bubble. */
     private sizeChangeListeners: (() => void)[] = [];
 
-     /** Functions listening for changes to the position of this bubble. */
+    /** Functions listening for changes to the position of this bubble. */
     private positionChangeListeners: (() => void)[] = []
 
     /** The text of this bubble. */
@@ -68,11 +68,10 @@ export class TextInputBubble extends Bubble {
         protected ownerRect?: Blockly.utils.Rect,
         protected readonly readOnly?: boolean
     ) {
-        super(workspace, anchor, ownerRect);
+        super(workspace, anchor, ownerRect, TextInputBubble.createTextArea());
         dom.addClass(this.svgRoot, 'blocklyTextInputBubble');
-        ({ inputRoot: this.inputRoot, textArea: this.textArea } = this.createEditor(
-            this.contentContainer,
-        ));
+        this.textArea = this.getFocusableElement() as HTMLTextAreaElement;
+        this.inputRoot = this.createEditor(this.contentContainer, this.textArea);
         this.resizeGroup = this.createResizeHandle(this.svgRoot, workspace);
         this.setSize(this.DEFAULT_SIZE, true);
 
@@ -112,11 +111,20 @@ export class TextInputBubble extends Bubble {
         this.positionChangeListeners.push(listener);
     }
 
-    /** Creates the editor UI for this bubble. */
-    private createEditor(container: SVGGElement): {
-        inputRoot: SVGForeignObjectElement;
-        textArea: HTMLTextAreaElement;
-    } {
+    private static createTextArea(): HTMLTextAreaElement {
+        const textArea = document.createElementNS(
+            dom.HTML_NS,
+            'textarea',
+        ) as HTMLTextAreaElement;
+        textArea.className = 'blocklyTextarea blocklyText';
+        return textArea;
+    }
+
+    /** Creates and returns the UI container element for this bubble's editor. */
+    private createEditor(
+        container: SVGGElement,
+        textArea: HTMLTextAreaElement,
+    ): SVGForeignObjectElement {
         const inputRoot = dom.createSvgElement(
             Blockly.utils.Svg.FOREIGNOBJECT,
             {
@@ -137,26 +145,13 @@ export class TextInputBubble extends Bubble {
         body.setAttribute('xmlns', dom.HTML_NS);
         body.className = 'blocklyMinimalBody';
 
-        const textArea = document.createElementNS(
-            dom.HTML_NS,
-            'textarea',
-        ) as HTMLTextAreaElement;
-        textArea.className = 'blocklyTextarea blocklyText';
         textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
-
-        if (this.readOnly) {
-            textArea.setAttribute("disabled", "true");
-        }
-
         body.appendChild(textArea);
         inputRoot.appendChild(body);
 
         this.bindTextAreaEvents(textArea);
-        setTimeout(() => {
-            textArea.focus();
-        }, 0);
 
-        return { inputRoot, textArea };
+        return inputRoot;
     }
 
     /** Binds events to the text area element. */
@@ -166,13 +161,6 @@ export class TextInputBubble extends Bubble {
             e.stopPropagation();
         });
 
-        browserEvents.conditionalBind(
-            textArea,
-            'focus',
-            this,
-            this.onStartEdit,
-            true,
-        );
         browserEvents.conditionalBind(textArea, 'change', this, this.onTextChange);
     }
 
@@ -301,17 +289,6 @@ export class TextInputBubble extends Bubble {
             false,
         );
         this.onSizeChange();
-    }
-
-    /**
-     * Handles starting an edit of the text area. Brings the bubble to the front.
-     */
-    private onStartEdit() {
-        if (this.bringToFront()) {
-            // Since the act of moving this node within the DOM causes a loss of
-            // focus, we need to reapply the focus.
-            this.textArea.focus();
-        }
     }
 
     /** Handles a text change event for the text area. Calls event listeners. */

--- a/pxtblocks/plugins/flyout/flyoutButton.ts
+++ b/pxtblocks/plugins/flyout/flyoutButton.ts
@@ -10,6 +10,12 @@ export interface ExtendedButtonInfo extends Blockly.utils.toolbox.LabelInfo {
     "web-line-width": string;
 }
 
+// Copied from toolbox.tsx
+const brandIcons = {
+    '\uf287': 'usb', '\uf368': 'accessible-icon', '\uf170': 'adn', '\uf1a7': 'pied-piper-pp', '\uf1b6': 'steam', '\uf294': 'bluetooth-b',
+    '\uf1d0': 'rebel', '\uf136': 'maxcdn', '\uf1aa': 'joomla', '\uf213': 'sellsy', '\uf20e': 'connectdevelop', '\uf113': 'github-alt'
+};
+
 export class FlyoutButton extends Blockly.FlyoutButton {
     constructor(
         workspace: Blockly.WorkspaceSvg,
@@ -62,10 +68,11 @@ export class FlyoutButton extends Blockly.FlyoutButton {
         const iconColor = def["web-icon-color"];
 
         if (icon || iconClass) {
+            const extraIconClass = Object.keys(brandIcons).includes(icon) ? 'brandIcon' : ''
             const svgIcon = Blockly.utils.dom.createSvgElement(
                 'text',
                 {
-                    'class': iconClass ? 'blocklyFlyoutLabelIcon ' + iconClass : 'blocklyFlyoutLabelIcon',
+                    'class': `blocklyFlyoutLabelIcon${iconClass ? ' ' + iconClass : ''}${extraIconClass ? ' ' + extraIconClass : ''}`,
                     'x': 0, 'y': 0, 'text-anchor': 'start'
                 },
                 svgGroup
@@ -83,10 +90,13 @@ export class FlyoutButton extends Blockly.FlyoutButton {
             const iconWidth = Blockly.utils.dom.getTextWidth(svgIcon) + 2 * Blockly.FlyoutButton.TEXT_MARGIN_X
             this.width += iconWidth;
 
+            const rect = svgGroup.getElementsByClassName("blocklyFlyoutLabelBackground").item(0) as SVGRectElement;
+            rect.setAttribute('width', String(this.width));
+
             for (let i = 0; i < svgGroup.children.length; i++) {
                 const el = svgGroup.children.item(i);
 
-                if (el !== svgIcon) {
+                if (el !== svgIcon && el !== rect) {
                     const x = Number(el.getAttribute("x"));
                     el.setAttribute("x", (x + iconWidth) + "")
                 }

--- a/pxtblocks/plugins/math/fieldSlider.ts
+++ b/pxtblocks/plugins/math/fieldSlider.ts
@@ -175,7 +175,11 @@ export class FieldSlider extends Blockly.FieldNumber {
     }
 
     protected showEditor_(_e?: Event, quietInput?: boolean): void {
-        super.showEditor_(_e, quietInput);
+        // Align with Blockly's approach in https://github.com/google/blockly-samples/blob/master/plugins/field-slider/src/field_slider.ts
+        // Always quiet the input for the super constructor, as we don't want to
+        // focus on the text field, and we don't want to display the modal
+        // editor on mobile devices.
+        super.showEditor_(_e, true);
 
         Blockly.DropDownDiv.hideWithoutAnimation();
         Blockly.DropDownDiv.clearContent();
@@ -194,6 +198,10 @@ export class FieldSlider extends Blockly.FieldNumber {
         Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_ as Blockly.BlockSvg, undefined, undefined, false);
 
         this.addEventListeners();
+
+        if (!quietInput) {
+            this.htmlInput_.focus();
+        }
     }
 
     protected addSlider_(contentDiv: Element) {

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -258,7 +258,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                     .then(() => projectView.printCode());
                             }
                             case "pair": {
-                                return projectView.pairAsync().then(() => {});
+                                return projectView.pairDialogAsync().then(() => {});
                             }
                             case "info": {
                                 return Promise.resolve()

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -3,6 +3,7 @@ namespace pxt.commands {
         Failed = 0,
         Success = 1,
         UserRejected = 2,
+        DownloadOnly = 3,
     }
 
     export interface RecompileOptions {

--- a/pxtlib/service.ts
+++ b/pxtlib/service.ts
@@ -1751,11 +1751,12 @@ namespace ts.pxtc.service {
     }
 
     export interface ExtensionMeta {
-        name: string,
-        fullName?: string,
-        description?: string,
-        imageUrl?: string,
-        type?: ExtensionType
+        name: string;
+        displayName?: string;
+        fullRepo?: string;
+        description?: string;
+        imageUrl?: string;
+        type?: ExtensionType;
         learnMoreUrl?: string;
 
         pkgConfig?: pxt.PackageConfig; // Added if the type is Bundled

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -498,7 +498,7 @@ namespace pxsim {
             }
         }
 
-        function fmtInfo(fmt: NumberFormat) {
+        export function fmtInfo(fmt: NumberFormat) {
             let size = fmtInfoCore(fmt)
             let signed = false
             if (size < 0) {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -499,6 +499,13 @@ namespace pxsim {
         class Channel {
             generator: OscillatorNode | AudioBufferSourceNode;
             gain: GainNode
+
+            constructor() {
+                this.gain = context().createGain();
+                this.gain.connect(destination);
+                this.gain.gain.value = 0;
+            }
+
             disconnectNodes() {
                 if (this.gain)
                     disconnectVca(this.gain, this.generator)
@@ -605,16 +612,8 @@ namespace pxsim {
                 let nodes: AudioBufferSourceNode[] = [];
                 let nextTime = context().currentTime;
                 let allScheduled = false;
-                const channel = new Channel();
-
-                channel.gain = context().createGain();
-                channel.gain.gain.value = 0;
+                const channel = getChannel();
                 channel.gain.gain.setValueAtTime(volume, context().currentTime);
-                channel.gain.connect(destination);
-
-                if (channels.length > 20)
-                    channels[0].remove()
-                channels.push(channel);
 
                 const checkCancel = () => {
                     if (isCancelled && isCancelled() || !channel.gain) {
@@ -687,17 +686,8 @@ namespace pxsim {
                 soundEventCallback?.("playinstructions", instructions);
                 let resolved = false;
                 let ctx = context();
-                let channel = new Channel()
-
-                if (channels.length > 20)
-                    channels[0].remove()
-                channels.push(channel);
-
-
-                channel.gain = ctx.createGain();
+                let channel = getChannel();
                 channel.gain.gain.value = 1;
-
-                channel.gain.connect(destination);
 
                 const oscillators: pxt.Map<OscillatorNode | AudioBufferSourceNode> = {};
                 const gains: pxt.Map<GainNode> = {};
@@ -861,6 +851,81 @@ namespace pxsim {
                 if (channel == 9) // drums don't call noteOff
                     setTimeout(() => stopTone(), 500);
             }
+        }
+
+        export interface PlaySampleResult {
+            promise: Promise<void>;
+            cancel: () => void;
+        }
+
+        export function startSamplePlayback(sample: RefBuffer, format: BufferMethods.NumberFormat, sampleRange: number, sampleRate: number, gain: number): PlaySampleResult {
+            let channel: Channel;
+            let _resolve: () => void;
+
+            const cancel = () => {
+                if (!channel) return;
+                channel.remove();
+                channel = undefined;
+                _resolve();
+            }
+
+            const promise = new Promise<void>(resolve => {
+                _resolve = resolve;
+                let playbackRate = 1;
+                // chrome errors out if the sample rate is outside [3000, 768000]
+                if (sampleRate < 3000) {
+                    playbackRate = sampleRate / 3000;
+                    sampleRate = 3000;
+                }
+                else if (sampleRate > 768000) {
+                    playbackRate = sampleRate / 768000;
+                    sampleRate = 768000;
+                }
+
+
+                const size = BufferMethods.fmtInfo(format).size;
+                const buf = context().createBuffer(
+                    1,
+                    sample.data.length / size,
+                    sampleRate
+                );
+
+                const data = buf.getChannelData(0);
+
+                for (let i = 0; i < buf.length; i++) {
+                    data[i] = (BufferMethods.getNumber(sample, format, i * size) / sampleRange) * 2 - 1
+                }
+
+                channel = getChannel();
+
+                const node = context().createBufferSource();;
+                node.playbackRate.value = playbackRate;
+
+                channel.gain.gain.value = gain;
+                channel.generator = node;
+                channel.generator.buffer = buf;
+                channel.generator.connect(channel.gain);
+                channel.generator.start(0);
+
+                channel.generator.addEventListener("ended", () => {
+                    channel.remove();
+                    channel = undefined;
+                    resolve();
+                });
+            });
+
+            return {
+                promise,
+                cancel
+            };
+        }
+
+        function getChannel() {
+            if (channels.length > 20)
+                channels[0].remove();
+            const channel = new Channel();
+            channels.push(channel);
+            return channel;
         }
     }
 

--- a/theme/toolbox.less
+++ b/theme/toolbox.less
@@ -233,6 +233,9 @@ div.blocklyTreeIcon span {
 .blocklyFlyoutLabelIcon.blocklyFlyoutIconfunctions {
     font-family: xicon !important;
 }
+.blocklyFlyoutLabelIcon.brandIcon {
+    font-family: 'brand-icons';
+}
 .blocklyTreeIcon.image-icon {
     background-image: var(--image-icon-url);
     width: 30px;

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3287,8 +3287,8 @@ export class ProjectView
             );
     }
 
-    pairAsync(): Promise<boolean> {
-        return cmds.pairAsync();
+    pairDialogAsync(): Promise<pxt.commands.WebUSBPairResult> {
+        return cmds.pairDialogAsync();
     }
 
     ///////////////////////////////////////////////////////////
@@ -3330,7 +3330,7 @@ export class ProjectView
         const variants = pxt.getHwVariants()
         if (variants.length == 0)
             return false
-        let pairAsync = () => cmds.pairAsync()
+        let pairAsync = () => cmds.pairDialogAsync()
             .then(() => {
                 this.checkForHwVariant()
             }, err => {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -2294,7 +2294,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             }
         });
 
-        this.editor.options.readOnly = debugging || pxt.shell.isReadOnly();
+        this.editor.setIsReadOnly(debugging || pxt.shell.isReadOnly());
     }
 
     protected enableBreakpoint(block: Blockly.Block, enabled: boolean) {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -278,7 +278,7 @@ export async function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.comma
             // TODO: slightly different flow vs implicit, as this is in a 'half paired' state?
             // Ideally, we should be including this in the pairing webusb.tsx pairing dialog flow
             // directly instead of deferring it all the way here.
-            await pairAsync();
+            await pairDialogAsync();
             return hidDeployCoreAsync(resp, d);
         } else if (e.message === "timeout") {
             pxt.tickEvent("hid.flash.timeout");
@@ -548,7 +548,7 @@ export async function maybeReconnectAsync(pairIfDeviceNotFound = false, skipIfCo
                 return true;
             } catch (e) {
                 if (e.type == "devicenotfound") {
-                    return !!pairIfDeviceNotFound && pairAsync();
+                    return !!pairIfDeviceNotFound && pairDialogAsync();
                 } else if (e.type == "inittimeout") {
                     pxt.tickEvent("hid.flash.inittimeout");
                     await showReconnectDeviceInstructionsAsync(core.confirmAsync);
@@ -558,11 +558,12 @@ export async function maybeReconnectAsync(pairIfDeviceNotFound = false, skipIfCo
         } finally {
             reconnectPromise = undefined;
         }
-    })();
+    })().then(res => res === pxt.commands.WebUSBPairResult.Success);
     return reconnectPromise;
 }
 
-export async function pairAsync(implicitlyCalled?: boolean): Promise<boolean> {
+
+export async function pairDialogAsync(implicitlyCalled?: boolean): Promise<pxt.commands.WebUSBPairResult> {
     pxt.tickEvent("cmds.pair")
     const res = await pxt.commands.webUsbPairDialogAsync(
         pxt.usb.pairAsync,
@@ -574,19 +575,15 @@ export async function pairAsync(implicitlyCalled?: boolean): Promise<boolean> {
         case pxt.commands.WebUSBPairResult.Success:
             try {
                 await maybeReconnectAsync(false, true);
-                return true;
             } catch (e) {
                 // Device
                 core.infoNotification(lf("Oops, connection failed."));
-                return false;
+                return pxt.commands.WebUSBPairResult.Failed;
             }
         case pxt.commands.WebUSBPairResult.Failed:
             core.infoNotification(lf("Oops, no device was paired."));
-            return false;
-        case pxt.commands.WebUSBPairResult.UserRejected:
-            // User exited pair flow intentionally
-            return false;
     }
+    return res;
 
 }
 

--- a/webapp/src/components/soundEffectEditor/SoundGallery.tsx
+++ b/webapp/src/components/soundEffectEditor/SoundGallery.tsx
@@ -24,17 +24,32 @@ interface SoundGalleryItemProps extends SoundGalleryItem {
     selectKeyDown: (evt: React.KeyboardEvent<HTMLElement>) => void;
 }
 
-type GalleryItem = Record<string, HTMLElement>;
 
 export const SoundGallery = (props: SoundGalleryProps) => {
     const { sounds, onSoundSelected, visible, useMixerSynthesizer } = props;
 
-    const selectItemRefs = React.useRef<[GalleryItem]>([{}]);
-    const playItemRefs = React.useRef<[GalleryItem]>([{}]);
+    const selectItemRefs = React.useRef<HTMLDivElement[]>([]);
+    const playItemRefs = React.useRef<HTMLButtonElement[]>([]);
     const selectedCoord = React.useRef<{row: number, col: "select" | "preview"}>({row: 0, col: "select"});
 
     const focusSelectOrPlayElement = React.useCallback((e: React.KeyboardEvent<HTMLElement> | React.FocusEvent) => {
-        (selectedCoord.current.col === "select" ? selectItemRefs : playItemRefs).current[0][selectedCoord.current.row].focus();
+        if (e.type === "focus") {
+            // Check to see if this focus event is coming from a click on a child element
+            const playIndex = playItemRefs.current.indexOf(e.target as HTMLButtonElement);
+            if (playIndex !== -1) {
+                selectedCoord.current = {col: "preview", row: playIndex};
+                return;
+            }
+
+            const selectIndex = selectItemRefs.current.indexOf(e.target as HTMLDivElement);
+            if (selectIndex !== -1) {
+                selectedCoord.current = {col: "select", row: selectIndex};
+                return;
+            }
+        }
+
+        const elements = (selectedCoord.current.col === "select" ? selectItemRefs : playItemRefs).current;
+        elements[selectedCoord.current.row].focus();
         e.preventDefault();
     }, []);
 
@@ -95,8 +110,8 @@ export const SoundGallery = (props: SoundGalleryProps) => {
                             {...item}
                             useMixerSynthesizer={useMixerSynthesizer}
 
-                            selectReference={ref => selectItemRefs.current[0][index] = ref}
-                            playReference={ref => playItemRefs.current[0][index] = ref}
+                            selectReference={ref => selectItemRefs.current[index] = ref}
+                            playReference={ref => playItemRefs.current[index] = ref}
 
                             previewKeyDown={evt => handleKeyDown(prev, next, index, evt)}
                             selectKeyDown={evt => handleKeyDown(prev, next, index, evt)}

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -263,7 +263,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     pair() {
         pxt.tickEvent("menu.pair");
-        this.props.parent.pairAsync();
+        this.props.parent.pairDialogAsync();
     }
 
     pairBluetooth() {

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -6,6 +6,7 @@ import * as sui from "./sui";
 import * as core from "./core";
 import * as auth from "./auth";
 import * as pkg from "./package";
+import * as Blockly from "blockly";
 import { fireClickOnEnter } from "./util";
 
 import IProjectView = pxt.editor.IProjectView;
@@ -643,10 +644,15 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
     toggleBuiltInHelp(help: pxt.editor.BuiltInHelp, focusIfVisible: boolean) {
         const url = `${builtInPrefix}${help}`;
         if (this.state.docsUrl === url && !this.state.sideDocsCollapsed && !focusIfVisible) {
-            this.toggleVisibility();
-            this.props.parent.editor.focusWorkspace();
+            const wasEditorFocused = Blockly.getFocusManager().getFocusedTree();
+            this.props.parent.setState({ sideDocsCollapsed: true });
+
+            if (!wasEditorFocused) {
+                this.props.parent.editor.focusWorkspace();
+            }
         } else {
             this.openingSideDoc = true;
+            Blockly.hideChaff(true);
             this.setUrl(url);
         }
     }
@@ -661,6 +667,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
     collapse() {
         this.props.parent.setState({ sideDocsCollapsed: true });
+        this.props.parent.editor.focusWorkspace();
     }
 
     isCollapsed() {
@@ -707,6 +714,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
     private handleKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
         if (ev.key == "Escape") {
+            ev.stopPropagation();
             this.collapse();
         }
     }

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -13,7 +13,7 @@ import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 import { TimeMachine } from "./timeMachine";
 import { fireClickOnEnter } from "./util";
-import { pairAsync } from "./cmds";
+import { pairDialogAsync } from "./cmds";
 import { invalidate } from "./data";
 
 import IProjectView = pxt.editor.IProjectView;
@@ -752,8 +752,8 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean, redeploy?:
 
     const onPairClicked = async () => {
         core.hideDialog();
-        const successfulPairing = await pairAsync(true);
-        if (redeploy && successfulPairing)
+        const pairingStatus = await pairDialogAsync();
+        if (redeploy && pairingStatus === pxt.commands.WebUSBPairResult.Success)
             await redeploy();
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -50,10 +50,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         this.props.parent.updateHeaderName(name);
     }
 
-    compile(view?: string) {
+    compile(view?: string, saveOnly?: boolean) {
         this.setState({ compileState: "compiling" });
         pxt.tickEvent("editortools.download", { view: view, collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        this.props.parent.compile();
+        this.props.parent.compile(saveOnly);
     }
 
     saveFile(view?: string) {
@@ -189,13 +189,18 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        let pairResult = pxt.commands.WebUSBPairResult.Success;
         if (this.shouldShowPairingDialogOnDownload()
             && !pxt.packetio.isConnected()
             && !pxt.packetio.isConnecting()
         ) {
-            await cmds.pairAsync(true);
+            pairResult = await cmds.pairDialogAsync(true);
         }
-        this.compile();
+        if (pairResult === pxt.commands.WebUSBPairResult.Success) {
+            this.compile(undefined, false);
+        } else if (pairResult === pxt.commands.WebUSBPairResult.DownloadOnly) {
+            this.compile(undefined, true);
+        }
     }
 
     protected onFileDownloadClick = async () => {
@@ -207,7 +212,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onPairClick = () => {
         pxt.tickEvent("editortools.pair", undefined, { interactiveConsent: true });
-        this.props.parent.pairAsync();
+        this.props.parent.pairDialogAsync();
     }
 
     protected onCannotPairClick = async () => {

--- a/webapp/src/extensionsBrowser.tsx
+++ b/webapp/src/extensionsBrowser.tsx
@@ -303,7 +303,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
             imageUrl: pxt.github.repoIconUrl(r),
             repo: r,
             description: r.description,
-            fullName: r.fullName
+            fullRepo: r.fullName
         }
     }
 
@@ -360,6 +360,7 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
     function packageConfigToExtensionMeta(p: pxt.PackageConfig): ExtensionMeta {
         return {
             name: p.name,
+            displayName: p.displayName,
             imageUrl: p.icon,
             type: ExtensionType.Bundled,
             learnMoreUrl: `/reference/${p.name}`,
@@ -458,22 +459,23 @@ export const ExtensionsBrowser = (props: ExtensionsProps) => {
         const { extensionInfo } = props;
         const {
             description,
-            fullName,
+            fullRepo,
             imageUrl,
             learnMoreUrl,
             loading,
             name,
+            displayName,
             repo,
             type,
         } = extensionInfo;
 
         return <ExtensionCard
-            title={name || fullName}
+            title={displayName || name || fullRepo}
             description={description}
             imageUrl={imageUrl}
             extension={extensionInfo}
             onClick={installExtension}
-            learnMoreUrl={learnMoreUrl || (fullName ? `/pkg/${fullName}` : undefined)}
+            learnMoreUrl={learnMoreUrl || (fullRepo ? `/pkg/${fullRepo}` : undefined)}
             loading={loading}
             label={pxt.isPkgBeta(extensionInfo) ? lf("Beta") : undefined}
             showDisclaimer={type != ExtensionType.Bundled && repo?.status != pxt.github.GitRepoStatus.Approved}

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -1246,6 +1246,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     }
 
     focusWorkspace(): void {
+        if (!this.editor) return;
         this.editor.focus();
     }
 

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -524,7 +524,8 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
             || charCode == 39 /* Right arrow key */
             || charCode == 17 /* Ctrl Key */
             || charCode == 16 /* Shift Key */
-            || charCode == 91 /* Cmd Key */) {
+            || charCode == 91 /* Cmd Key */
+            || charCode == 191 /* Slash Key*/) {
             // Escape tab and shift key
         } else {
             this.setSearch();


### PR DESCRIPTION
On mobile / Android / iPad, a prompt is used to change the value of a `FieldInput`. If the prompt is used, the text input is not rendered into the widget div. We then try to add event handlers to an input that doesn't exist which results in an error. There may also be focus manager issues that result from this. 

This PR aligns with Blockly's [`field_slider`](https://github.com/google/blockly-samples/blob/master/plugins/field-slider/src/field_slider.ts) by never calling the prompt for these fields. Instead, users can use the dropdown or slider to edit the values.

The text dropdown is a slightly different case to the slider as only a subset of values can be selected via the dropdown.

Can be tested on a real mobile / Android / iPad, or use Chrome dev tools -> three dots menu in top right -> more tools -> network conditions -> choose “Chrome - Android Mobile” as user agent.