### PR TITLE
Improve search category selected state

### DIFF
--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -550,13 +550,15 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         };
         Blockly.Toolbox.prototype.clearSelection = function () {
             that.hideFlyout();
+            that.toolbox.clearExpandedItem();
         };
         const oldToolboxOnTreeBlur = Blockly.Toolbox.prototype.onTreeBlur;
         (Blockly.Toolbox as any).prototype.onTreeBlur = function (nextTree: Blockly.IFocusableTree | null) {
             // If the search box is focused and there are search results, the flyout is set to forceOpen.
             // Otherwise, the flyout closes and then re-opens causing an unpleasant visual effect.
             if ((that.editor.getFlyout() as pxtblockly.CachingFlyout).forceOpen) {
-                that.toolbox.selectFirstItem();
+                that.toolbox.clear();
+                that.toolbox.clearExpandedItem();
                 that.setFlyoutForceOpen(false);
                 return;
             }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -452,7 +452,6 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
     handleCategoryTreeFocus = (e: React.FocusEvent<HTMLDivElement>) => {
         // Don't handle focus events triggered by pointer events.
         if (!this.shouldHandleCategoryTreeFocus) {
-            this.shouldHandleCategoryTreeFocus = true;
             return;
         }
         if (!this.rootElement) return;
@@ -479,6 +478,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
         e.preventDefault();
         this.shouldHandleCategoryTreeFocus = false;
         (this.refs.categoryTree as HTMLElement).focus();
+        this.shouldHandleCategoryTreeFocus = true;
     }
 
     isRtl() {
@@ -1128,7 +1128,15 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
             // Don't trigger scroll behaviour inside the toolbox.
             e.preventDefault();
         } else if (charCode === 13 /* Enter */) {
-            this.searchImmediate().then(() => this.props.parent.moveFocusToFlyout());
+            this.searchImmediate().then(() => {
+                if (toolbox.state.hasSearch) {
+                    toolbox.setState({
+                        selectedItem: 'search'
+                    });
+                    toolbox.setSelectedItem(toolbox.refs.searchCategory as CategoryItem);
+                }
+                this.props.parent.moveFocusToFlyout();
+            });
         }
     }
 
@@ -1165,10 +1173,6 @@ export class ToolboxSearch extends data.Component<ToolboxSearchProps, ToolboxSea
         newState.hasSearch = hasSearch;
         newState.searchBlocks = blocks;
         newState.focusSearch = true;
-        if (hasSearch) {
-            newState.selectedItem = 'search';
-            toolbox.setSelectedItem(toolbox.refs.searchCategory as CategoryItem)
-        }
         toolbox.setState(newState);
 
         this.setState({ searchAccessibilityLabel: searchAccessibilityLabel });


### PR DESCRIPTION
Only select / highlight the search category when it is actually selected by the user. This can happen if the user hits "Enter", "Tab", or "ArrowDown" from the search input. The previous behaviour resulted in users thinking they could use "ArrowRight" from the search input to move into the flyout and this PR aims to address that.

This PR also fixes a toolbox focus bug resulting from clicking on the toolbox, then focusing the toolbox again via keyboard. This resulted in no category being selected by default.

Draft as similar changes need making to the Monaco side.