### PR TITLE
Add duplicate shortcut if keyboard controls are active

### DIFF
--- a/pxtblocks/contextMenu/blockItems.ts
+++ b/pxtblocks/contextMenu/blockItems.ts
@@ -12,14 +12,14 @@ export enum BlockContextWeight {
     Help = 50,
 }
 
-export function registerBlockitems() {
+export function registerBlockitems(keyboardControlsActive: boolean) {
     // Unregister the builtin options that we don't use
     Blockly.ContextMenuRegistry.registry.unregister("blockDuplicate");
     Blockly.ContextMenuRegistry.registry.unregister("blockCollapseExpand");
     Blockly.ContextMenuRegistry.registry.unregister("blockHelp");
     Blockly.ContextMenuRegistry.registry.unregister("blockInline");
 
-    registerDuplicate();
+    registerDuplicate(keyboardControlsActive);
     registerCollapseExpandBlock();
     registerHelp();
 
@@ -110,10 +110,10 @@ function registerHelp() {
     Blockly.ContextMenuRegistry.registry.register(helpOption);
 }
 
-function registerDuplicate() {
+function registerDuplicate(keyboardControlsActive: boolean) {
     const duplicateOption: Blockly.ContextMenuRegistry.RegistryItem = {
         displayText() {
-            return lf("Duplicate")
+            return keyboardControlsActive ? lf("Duplicate (D)") : lf("Duplicate")
         },
         preconditionFn(scope: Blockly.ContextMenuRegistry.Scope) {
             const block = scope.block;

--- a/pxtblocks/contextMenu/contextMenu.ts
+++ b/pxtblocks/contextMenu/contextMenu.ts
@@ -4,7 +4,7 @@ import { registerWorkspaceItems } from "./workspaceItems";
 import { onWorkspaceContextMenu } from "../external";
 import { registerBlockitems } from "./blockItems";
 
-export function initContextMenu() {
+export function initContextMenu(keyboardControlsActive: boolean) {
     const msg = Blockly.Msg;
 
     // FIXME (riknoll): Not all of these are still used
@@ -24,7 +24,7 @@ export function initContextMenu() {
     msg.HELP = lf("Help");
 
     registerWorkspaceItems();
-    registerBlockitems();
+    registerBlockitems(keyboardControlsActive);
 }
 
 export function setupWorkspaceContextMenu(workspace: Blockly.WorkspaceSvg) {

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -588,7 +588,7 @@ export function cleanBlocks() {
  * Used by pxtrunner to initialize blocks in the docs
  */
 export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
-    init(blockInfo);
+    init(blockInfo, false);
     initCopyPaste(false);
     injectBlocks(blockInfo);
 }
@@ -597,18 +597,18 @@ export function initializeAndInject(blockInfo: pxtc.BlocksInfo) {
  * Used by main app to initialize blockly blocks.
  * Blocks are injected separately by called injectBlocks
  */
-export function initialize(blockInfo: pxtc.BlocksInfo) {
-    init(blockInfo);
+export function initialize(blockInfo: pxtc.BlocksInfo, keyboardControlsActive: boolean) {
+    init(blockInfo, keyboardControlsActive);
     initJresIcons(blockInfo);
 }
 
 let blocklyInitialized = false;
-function init(blockInfo: pxtc.BlocksInfo) {
+function init(blockInfo: pxtc.BlocksInfo, keyboardControlsActive: boolean) {
     if (blocklyInitialized) return;
     blocklyInitialized = true;
 
     initFieldEditors();
-    initContextMenu();
+    initContextMenu(keyboardControlsActive);
     initOnStart();
     initMath(blockInfo);
     initVariables();

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -239,7 +239,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     this.blockInfo = bi;
 
                     // Initialize blocks in Blockly and update our toolbox
-                    pxtblockly.initialize(this.blockInfo);
+                    pxtblockly.initialize(this.blockInfo, !!this.keyboardNavigation);
 
                     this.nsMap = this.partitionBlocks();
                     this.refreshToolbox();
@@ -651,6 +651,26 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                     flow(workspace, { useViewWidth: true });
                     return true
                 }
+            });
+
+            const copyShortcut = Blockly.ShortcutRegistry.registry.getRegistry()["keyboard_nav_copy"];
+            const pasteShortcut = Blockly.ShortcutRegistry.registry.getRegistry()["keyboard_nav_paste"];
+            Blockly.ShortcutRegistry.registry.register({
+                name: "duplicate",
+                preconditionFn: (_workspace, scope) => {
+                    const block = scope.focusedNode as Blockly.BlockSvg;
+                    if (!block?.isInFlyout && block?.isDeletable() && block?.isMovable() && block?.isDuplicatable()) {
+                        return true;
+                    }
+                    return false;
+                },
+                callback: (workspace, e, shortcut, scope) => {
+                    if (copyShortcut.callback(workspace, e, shortcut, scope)) {
+                        return pasteShortcut.callback(workspace, e, shortcut, scope)
+                    }
+                    return false;
+                },
+                keyCodes: [Blockly.ShortcutRegistry.registry.createSerializedKey(Blockly.utils.KeyCodes.D, null)]
             });
 
             // This must come after plugin initialization to override context menu

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -42,6 +42,7 @@ import { flow, initCopyPaste } from "../../pxtblocks";
 import { HIDDEN_CLASS_NAME } from "../../pxtblocks/plugins/flyout/blockInflater";
 import { AIFooter } from "../../react-common/components/controls/AIFooter";
 import { CREATE_VAR_BTN_ID } from "../../pxtblocks/builtins/variables";
+import { ShortcutNames } from "./shortcut_formatting";
 
 interface CopyDataEntry {
     version: 1;
@@ -656,7 +657,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
             const copyShortcut = Blockly.ShortcutRegistry.registry.getRegistry()["keyboard_nav_copy"];
             const pasteShortcut = Blockly.ShortcutRegistry.registry.getRegistry()["keyboard_nav_paste"];
             Blockly.ShortcutRegistry.registry.register({
-                name: "duplicate",
+                name: ShortcutNames.DUPLICATE_BLOCK,
                 preconditionFn: (_workspace, scope) => {
                     const block = scope.focusedNode as Blockly.BlockSvg;
                     if (!block?.isInFlyout && block?.isDeletable() && block?.isMovable() && block?.isDuplicatable()) {

--- a/webapp/src/components/KeyboardControlsHelp.tsx
+++ b/webapp/src/components/KeyboardControlsHelp.tsx
@@ -28,6 +28,7 @@ const KeyboardControlsHelp = () => {
                         <br /><span className="hint">{lf("Move with arrow keys")}</span>
                         <br /><span className="hint">{lf("Hold {0} for free movement", optionOrCtrl)}</span>
                     </Row>
+                    <Row name={lf("Duplicate")} shortcuts={[ShortcutNames.DUPLICATE_BLOCK]} />
                     <Row name={lf("Copy / paste")} shortcuts={[ShortcutNames.COPY, ShortcutNames.PASTE]} joiner="/" />
                     {cleanUpRow}
                     {contextMenuRow}
@@ -53,6 +54,7 @@ const KeyboardControlsHelp = () => {
                     <Row name={lf("Move in and out of a block")} shortcuts={[ShortcutNames.LEFT, ShortcutNames.RIGHT]} />
                     {editOrConfirmRow}
                     <Row name={lf("Cancel or exit")} shortcuts={[ShortcutNames.EXIT]} />
+                    <Row name={lf("Duplicate")} shortcuts={[ShortcutNames.DUPLICATE_BLOCK]} />
                     <Row name={lf("Copy")} shortcuts={[ShortcutNames.COPY]} />
                     <Row name={lf("Paste")} shortcuts={[ShortcutNames.PASTE]} />
                     <Row name={lf("Cut")} shortcuts={[ShortcutNames.CUT]} />

--- a/webapp/src/shortcut_formatting.ts
+++ b/webapp/src/shortcut_formatting.ts
@@ -21,6 +21,7 @@ export enum ShortcutNames {
   COPY = 'keyboard_nav_copy',
   CUT = 'keyboard_nav_cut',
   PASTE = 'keyboard_nav_paste',
+  DUPLICATE_BLOCK = 'duplicate_block',
   DELETE = 'delete',
   CREATE_WS_CURSOR = 'to_workspace',
   LIST_SHORTCUTS = 'list_shortcuts',


### PR DESCRIPTION
Add key to duplicate context menu if keyboard controls are active
Add duplicate to keyboard help documentation

Leaving in draft. Perhaps this will be upstreamed by the Blockly team, but this is a reasonable fallback if we want a duplicate shortcut for launch.