### PR TITLE
Add a cancel button to download dialog

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1345,8 +1345,9 @@ function uploadCoreAsync(opts: UploadOptions) {
 
     // check size
     const maxSize = checkFileSize(opts.fileList);
-    if (maxSize > 30000000) // 30Mb max
-        U.userError(`file too big for upload`);
+    const maxAllowedFileSize = (pxt.appTarget.cloud.maxFileSize || (30000000)); // default to 30Mb
+    if (maxSize > maxAllowedFileSize)
+        U.userError(`file too big for upload: ${maxSize} bytes, max is ${maxAllowedFileSize} bytes`);
     pxt.log('');
 
     if (opts.localDir)
@@ -6113,7 +6114,7 @@ function internalCheckDocsAsync(compileSnippets?: boolean, re?: string, fix?: bo
 
     const maxFileSize = checkFileSize(nodeutil.allFiles("docs", { maxDepth: 10, allowMissing: true, includeDirs: true, ignoredFileMarker: ".ignorelargefiles" }));
     if (!pxt.appTarget.ignoreDocsErrors
-        && maxFileSize > (pxt.appTarget.cloud.maxFileSize || (5000000)))
+        && maxFileSize > (pxt.appTarget.cloud.maxFileSize || (30000000)))
         U.userError(`files too big in docs folder`);
 
     // scan and fix image links

--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -955,7 +955,7 @@ declare namespace pxt.editor {
         saveAndCompile(): void;
         updateHeaderName(name: string): void;
         updateHeaderNameAsync(name: string): Promise<void>;
-        compile(): void;
+        compile(saveOnly?: boolean): void;
 
         setFile(fn: IFile, line?: number): void;
         setSideFile(fn: IFile, line?: number): void;
@@ -1093,7 +1093,7 @@ declare namespace pxt.editor {
         showPackageDialog(query?: string): void;
         showBoardDialogAsync(features?: string[], closeIcon?: boolean): Promise<void>;
         checkForHwVariant(): boolean;
-        pairAsync(): Promise<boolean>;
+        pairDialogAsync(): Promise<pxt.commands.WebUSBPairResult>;
 
         createModalClasses(classes?: string): string;
         showModalDialogAsync(options: ModalDialogOptions): Promise<void>;

--- a/pxtblocks/plugins/comments/bubble.ts
+++ b/pxtblocks/plugins/comments/bubble.ts
@@ -53,6 +53,7 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
 
     private dragStrategy = new Blockly.dragging.BubbleDragStrategy(this, this.workspace);
 
+    private focusableElement: SVGElement | HTMLElement;
 
     private topBar: SVGRectElement;
 
@@ -76,6 +77,7 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
         public readonly workspace: Blockly.WorkspaceSvg,
         protected anchor: Blockly.utils.Coordinate,
         protected ownerRect?: Blockly.utils.Rect,
+        overriddenFocusableElement?: SVGElement | HTMLElement,
     ) {
         this.id = Blockly.utils.idGenerator.getNextUniqueId();
         this.svgRoot = dom.createSvgElement(
@@ -138,6 +140,9 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
             },
             embossGroup
         );
+
+        this.focusableElement = overriddenFocusableElement ?? this.svgRoot;
+        this.focusableElement.setAttribute('id', this.id);
 
         Blockly.browserEvents.conditionalBind(
             this.background,
@@ -267,6 +272,7 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
     private onMouseDown(e: PointerEvent) {
         this.workspace.getGesture(e)?.handleBubbleStart(e, this);
         Blockly.common.setSelected(this);
+        Blockly.getFocusManager().focusNode(this);
     }
 
     /** Positions the bubble relative to its anchor. Does not render its tail. */
@@ -633,15 +639,17 @@ export abstract class Bubble implements Blockly.IDeletable, Blockly.IBubble, Blo
 
     select(): void {
         // Bubbles don't have any visual for being selected.
+        Blockly.common.fireSelectedEvent(this);
     }
 
     unselect(): void {
         // Bubbles don't have any visual for being selected.
+        Blockly.common.fireSelectedEvent(null);
     }
 
     /** See IFocusableNode.getFocusableElement. */
     getFocusableElement(): HTMLElement | SVGElement {
-      return this.svgRoot;
+        return this.focusableElement;
     }
 
     /** See IFocusableNode.getFocusableTree. */

--- a/pxtblocks/plugins/comments/textinput_bubble.ts
+++ b/pxtblocks/plugins/comments/textinput_bubble.ts
@@ -37,7 +37,7 @@ export class TextInputBubble extends Bubble {
     /** Functions listening for changes to the size of this bubble. */
     private sizeChangeListeners: (() => void)[] = [];
 
-     /** Functions listening for changes to the position of this bubble. */
+    /** Functions listening for changes to the position of this bubble. */
     private positionChangeListeners: (() => void)[] = []
 
     /** The text of this bubble. */
@@ -68,11 +68,10 @@ export class TextInputBubble extends Bubble {
         protected ownerRect?: Blockly.utils.Rect,
         protected readonly readOnly?: boolean
     ) {
-        super(workspace, anchor, ownerRect);
+        super(workspace, anchor, ownerRect, TextInputBubble.createTextArea());
         dom.addClass(this.svgRoot, 'blocklyTextInputBubble');
-        ({ inputRoot: this.inputRoot, textArea: this.textArea } = this.createEditor(
-            this.contentContainer,
-        ));
+        this.textArea = this.getFocusableElement() as HTMLTextAreaElement;
+        this.inputRoot = this.createEditor(this.contentContainer, this.textArea);
         this.resizeGroup = this.createResizeHandle(this.svgRoot, workspace);
         this.setSize(this.DEFAULT_SIZE, true);
 
@@ -112,11 +111,20 @@ export class TextInputBubble extends Bubble {
         this.positionChangeListeners.push(listener);
     }
 
-    /** Creates the editor UI for this bubble. */
-    private createEditor(container: SVGGElement): {
-        inputRoot: SVGForeignObjectElement;
-        textArea: HTMLTextAreaElement;
-    } {
+    private static createTextArea(): HTMLTextAreaElement {
+        const textArea = document.createElementNS(
+            dom.HTML_NS,
+            'textarea',
+        ) as HTMLTextAreaElement;
+        textArea.className = 'blocklyTextarea blocklyText';
+        return textArea;
+    }
+
+    /** Creates and returns the UI container element for this bubble's editor. */
+    private createEditor(
+        container: SVGGElement,
+        textArea: HTMLTextAreaElement,
+    ): SVGForeignObjectElement {
         const inputRoot = dom.createSvgElement(
             Blockly.utils.Svg.FOREIGNOBJECT,
             {
@@ -137,26 +145,13 @@ export class TextInputBubble extends Bubble {
         body.setAttribute('xmlns', dom.HTML_NS);
         body.className = 'blocklyMinimalBody';
 
-        const textArea = document.createElementNS(
-            dom.HTML_NS,
-            'textarea',
-        ) as HTMLTextAreaElement;
-        textArea.className = 'blocklyTextarea blocklyText';
         textArea.setAttribute('dir', this.workspace.RTL ? 'RTL' : 'LTR');
-
-        if (this.readOnly) {
-            textArea.setAttribute("disabled", "true");
-        }
-
         body.appendChild(textArea);
         inputRoot.appendChild(body);
 
         this.bindTextAreaEvents(textArea);
-        setTimeout(() => {
-            textArea.focus();
-        }, 0);
 
-        return { inputRoot, textArea };
+        return inputRoot;
     }
 
     /** Binds events to the text area element. */
@@ -166,13 +161,6 @@ export class TextInputBubble extends Bubble {
             e.stopPropagation();
         });
 
-        browserEvents.conditionalBind(
-            textArea,
-            'focus',
-            this,
-            this.onStartEdit,
-            true,
-        );
         browserEvents.conditionalBind(textArea, 'change', this, this.onTextChange);
     }
 
@@ -301,17 +289,6 @@ export class TextInputBubble extends Bubble {
             false,
         );
         this.onSizeChange();
-    }
-
-    /**
-     * Handles starting an edit of the text area. Brings the bubble to the front.
-     */
-    private onStartEdit() {
-        if (this.bringToFront()) {
-            // Since the act of moving this node within the DOM causes a loss of
-            // focus, we need to reapply the focus.
-            this.textArea.focus();
-        }
     }
 
     /** Handles a text change event for the text area. Calls event listeners. */

--- a/pxteditor/editorcontroller.ts
+++ b/pxteditor/editorcontroller.ts
@@ -258,7 +258,7 @@ export function bindEditorMessages(getEditorAsync: () => Promise<IProjectView>) 
                                     .then(() => projectView.printCode());
                             }
                             case "pair": {
-                                return projectView.pairAsync().then(() => {});
+                                return projectView.pairDialogAsync().then(() => {});
                             }
                             case "info": {
                                 return Promise.resolve()

--- a/pxtlib/cmds.ts
+++ b/pxtlib/cmds.ts
@@ -3,6 +3,7 @@ namespace pxt.commands {
         Failed = 0,
         Success = 1,
         UserRejected = 2,
+        DownloadOnly = 3,
     }
 
     export interface RecompileOptions {

--- a/pxtsim/libgeneric.ts
+++ b/pxtsim/libgeneric.ts
@@ -498,7 +498,7 @@ namespace pxsim {
             }
         }
 
-        function fmtInfo(fmt: NumberFormat) {
+        export function fmtInfo(fmt: NumberFormat) {
             let size = fmtInfoCore(fmt)
             let signed = false
             if (size < 0) {

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -499,6 +499,13 @@ namespace pxsim {
         class Channel {
             generator: OscillatorNode | AudioBufferSourceNode;
             gain: GainNode
+
+            constructor() {
+                this.gain = context().createGain();
+                this.gain.connect(destination);
+                this.gain.gain.value = 0;
+            }
+
             disconnectNodes() {
                 if (this.gain)
                     disconnectVca(this.gain, this.generator)
@@ -605,16 +612,8 @@ namespace pxsim {
                 let nodes: AudioBufferSourceNode[] = [];
                 let nextTime = context().currentTime;
                 let allScheduled = false;
-                const channel = new Channel();
-
-                channel.gain = context().createGain();
-                channel.gain.gain.value = 0;
+                const channel = getChannel();
                 channel.gain.gain.setValueAtTime(volume, context().currentTime);
-                channel.gain.connect(destination);
-
-                if (channels.length > 20)
-                    channels[0].remove()
-                channels.push(channel);
 
                 const checkCancel = () => {
                     if (isCancelled && isCancelled() || !channel.gain) {
@@ -687,17 +686,8 @@ namespace pxsim {
                 soundEventCallback?.("playinstructions", instructions);
                 let resolved = false;
                 let ctx = context();
-                let channel = new Channel()
-
-                if (channels.length > 20)
-                    channels[0].remove()
-                channels.push(channel);
-
-
-                channel.gain = ctx.createGain();
+                let channel = getChannel();
                 channel.gain.gain.value = 1;
-
-                channel.gain.connect(destination);
 
                 const oscillators: pxt.Map<OscillatorNode | AudioBufferSourceNode> = {};
                 const gains: pxt.Map<GainNode> = {};
@@ -861,6 +851,81 @@ namespace pxsim {
                 if (channel == 9) // drums don't call noteOff
                     setTimeout(() => stopTone(), 500);
             }
+        }
+
+        export interface PlaySampleResult {
+            promise: Promise<void>;
+            cancel: () => void;
+        }
+
+        export function startSamplePlayback(sample: RefBuffer, format: BufferMethods.NumberFormat, sampleRange: number, sampleRate: number, gain: number): PlaySampleResult {
+            let channel: Channel;
+            let _resolve: () => void;
+
+            const cancel = () => {
+                if (!channel) return;
+                channel.remove();
+                channel = undefined;
+                _resolve();
+            }
+
+            const promise = new Promise<void>(resolve => {
+                _resolve = resolve;
+                let playbackRate = 1;
+                // chrome errors out if the sample rate is outside [3000, 768000]
+                if (sampleRate < 3000) {
+                    playbackRate = sampleRate / 3000;
+                    sampleRate = 3000;
+                }
+                else if (sampleRate > 768000) {
+                    playbackRate = sampleRate / 768000;
+                    sampleRate = 768000;
+                }
+
+
+                const size = BufferMethods.fmtInfo(format).size;
+                const buf = context().createBuffer(
+                    1,
+                    sample.data.length / size,
+                    sampleRate
+                );
+
+                const data = buf.getChannelData(0);
+
+                for (let i = 0; i < buf.length; i++) {
+                    data[i] = (BufferMethods.getNumber(sample, format, i * size) / sampleRange) * 2 - 1
+                }
+
+                channel = getChannel();
+
+                const node = context().createBufferSource();;
+                node.playbackRate.value = playbackRate;
+
+                channel.gain.gain.value = gain;
+                channel.generator = node;
+                channel.generator.buffer = buf;
+                channel.generator.connect(channel.gain);
+                channel.generator.start(0);
+
+                channel.generator.addEventListener("ended", () => {
+                    channel.remove();
+                    channel = undefined;
+                    resolve();
+                });
+            });
+
+            return {
+                promise,
+                cancel
+            };
+        }
+
+        function getChannel() {
+            if (channels.length > 20)
+                channels[0].remove();
+            const channel = new Channel();
+            channels.push(channel);
+            return channel;
         }
     }
 

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3287,8 +3287,8 @@ export class ProjectView
             );
     }
 
-    pairAsync(): Promise<boolean> {
-        return cmds.pairAsync();
+    pairDialogAsync(): Promise<pxt.commands.WebUSBPairResult> {
+        return cmds.pairDialogAsync();
     }
 
     ///////////////////////////////////////////////////////////
@@ -3330,7 +3330,7 @@ export class ProjectView
         const variants = pxt.getHwVariants()
         if (variants.length == 0)
             return false
-        let pairAsync = () => cmds.pairAsync()
+        let pairAsync = () => cmds.pairDialogAsync()
             .then(() => {
                 this.checkForHwVariant()
             }, err => {

--- a/webapp/src/cmds.ts
+++ b/webapp/src/cmds.ts
@@ -278,7 +278,7 @@ export async function hidDeployCoreAsync(resp: pxtc.CompileResult, d?: pxt.comma
             // TODO: slightly different flow vs implicit, as this is in a 'half paired' state?
             // Ideally, we should be including this in the pairing webusb.tsx pairing dialog flow
             // directly instead of deferring it all the way here.
-            await pairAsync();
+            await pairDialogAsync();
             return hidDeployCoreAsync(resp, d);
         } else if (e.message === "timeout") {
             pxt.tickEvent("hid.flash.timeout");
@@ -548,7 +548,7 @@ export async function maybeReconnectAsync(pairIfDeviceNotFound = false, skipIfCo
                 return true;
             } catch (e) {
                 if (e.type == "devicenotfound") {
-                    return !!pairIfDeviceNotFound && pairAsync();
+                    return !!pairIfDeviceNotFound && pairDialogAsync();
                 } else if (e.type == "inittimeout") {
                     pxt.tickEvent("hid.flash.inittimeout");
                     await showReconnectDeviceInstructionsAsync(core.confirmAsync);
@@ -558,11 +558,12 @@ export async function maybeReconnectAsync(pairIfDeviceNotFound = false, skipIfCo
         } finally {
             reconnectPromise = undefined;
         }
-    })();
+    })().then(res => res === pxt.commands.WebUSBPairResult.Success);
     return reconnectPromise;
 }
 
-export async function pairAsync(implicitlyCalled?: boolean): Promise<boolean> {
+
+export async function pairDialogAsync(implicitlyCalled?: boolean): Promise<pxt.commands.WebUSBPairResult> {
     pxt.tickEvent("cmds.pair")
     const res = await pxt.commands.webUsbPairDialogAsync(
         pxt.usb.pairAsync,
@@ -574,19 +575,15 @@ export async function pairAsync(implicitlyCalled?: boolean): Promise<boolean> {
         case pxt.commands.WebUSBPairResult.Success:
             try {
                 await maybeReconnectAsync(false, true);
-                return true;
             } catch (e) {
                 // Device
                 core.infoNotification(lf("Oops, connection failed."));
-                return false;
+                return pxt.commands.WebUSBPairResult.Failed;
             }
         case pxt.commands.WebUSBPairResult.Failed:
             core.infoNotification(lf("Oops, no device was paired."));
-            return false;
-        case pxt.commands.WebUSBPairResult.UserRejected:
-            // User exited pair flow intentionally
-            return false;
     }
+    return res;
 
 }
 

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -263,7 +263,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     pair() {
         pxt.tickEvent("menu.pair");
-        this.props.parent.pairAsync();
+        this.props.parent.pairDialogAsync();
     }
 
     pairBluetooth() {

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -13,7 +13,7 @@ import Cloud = pxt.Cloud;
 import Util = pxt.Util;
 import { TimeMachine } from "./timeMachine";
 import { fireClickOnEnter } from "./util";
-import { pairAsync } from "./cmds";
+import { pairDialogAsync } from "./cmds";
 import { invalidate } from "./data";
 
 import IProjectView = pxt.editor.IProjectView;
@@ -752,8 +752,8 @@ export function renderBrowserDownloadInstructions(saveonly?: boolean, redeploy?:
 
     const onPairClicked = async () => {
         core.hideDialog();
-        const successfulPairing = await pairAsync(true);
-        if (redeploy && successfulPairing)
+        const pairingStatus = await pairDialogAsync();
+        if (redeploy && pairingStatus === pxt.commands.WebUSBPairResult.Success)
             await redeploy();
     }
 

--- a/webapp/src/editortoolbar.tsx
+++ b/webapp/src/editortoolbar.tsx
@@ -50,10 +50,10 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
         this.props.parent.updateHeaderName(name);
     }
 
-    compile(view?: string) {
+    compile(view?: string, saveOnly?: boolean) {
         this.setState({ compileState: "compiling" });
         pxt.tickEvent("editortools.download", { view: view, collapsed: this.getCollapsedState() }, { interactiveConsent: true });
-        this.props.parent.compile();
+        this.props.parent.compile(saveOnly);
     }
 
     saveFile(view?: string) {
@@ -189,13 +189,18 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onDownloadButtonClick = async () => {
         pxt.tickEvent("editortools.downloadbutton", { collapsed: this.getCollapsedState() }, { interactiveConsent: true });
+        let pairResult = pxt.commands.WebUSBPairResult.Success;
         if (this.shouldShowPairingDialogOnDownload()
             && !pxt.packetio.isConnected()
             && !pxt.packetio.isConnecting()
         ) {
-            await cmds.pairAsync(true);
+            pairResult = await cmds.pairDialogAsync(true);
         }
-        this.compile();
+        if (pairResult === pxt.commands.WebUSBPairResult.Success) {
+            this.compile(undefined, false);
+        } else if (pairResult === pxt.commands.WebUSBPairResult.DownloadOnly) {
+            this.compile(undefined, true);
+        }
     }
 
     protected onFileDownloadClick = async () => {
@@ -207,7 +212,7 @@ export class EditorToolbar extends data.Component<ISettingsProps, EditorToolbarS
 
     protected onPairClick = () => {
         pxt.tickEvent("editortools.pair", undefined, { interactiveConsent: true });
-        this.props.parent.pairAsync();
+        this.props.parent.pairDialogAsync();
     }
 
     protected onCannotPairClick = async () => {


### PR DESCRIPTION
Live demo: https://download-cancel-button.review-pxt.pages.dev/

<img width="594" alt="image" src="https://github.com/user-attachments/assets/4781f5fa-abad-4023-9e4f-e70bcabc3c86" />

This allows the user to leave the download flow on the first page without initiating a device pairing or downloading an artefact.

Note that, as a side effect, the cancel button causes the "Oops, device not paired" toast to appear. This is coincidental, but I have left it in as it arguably clarifies the user's action.

This is similar to the cancel button on Reset ("Cog menu -> Reset" in Makecode) but the cancel button order is reversed based on feedback on [a previous PR](https://github.com/microsoft/pxt/pull/10483#issuecomment-2790651652).

<img width="736" alt="image" src="https://github.com/user-attachments/assets/b6c8a548-bde5-43e5-8457-5945a8f7215a" />

### Technical changes

As part of this work, clarified the difference in behaviour between the different state transitions in the download flow. Previously we assumed that any early exit from the Download dialogs should trigger a download, so in order to cancel the flow we need additional information about the result, including:

* UserRejected
* Failure
* DownloadOnly
* Success

Because it is current and desired behaviour, the default close behaviour is `DownloadOnly`, and the only call to `UserRejected` is from the new cancel button.

### API changes

I have modified a few functions in the `pxt` namespace

* `pxt.editor.compile` - exposed the optional `saveOnly` flag in the API type definition, this already existed and should not break existing consumers
* `pairAsync` - renamed to `pairDialogAsync` to distinguish from the backend WebUSB `pairAsync`. Changed the return type from `boolean` to `WebUSBPairResult` so that the consumer in `EditorToolbar.onDownloadButtonClick` can correctly manage the ensuing compile flow.
* `pxt.commands.WebUSBPairResult` - extended to include a `DownloadOnly` state that becomes necessary to know what is expected when breaking out of the multi-dialog flow normally