### PR TITLE
Handle focus on keyboard help closes + other fixes

### DIFF
--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -6,6 +6,7 @@ import * as sui from "./sui";
 import * as core from "./core";
 import * as auth from "./auth";
 import * as pkg from "./package";
+import * as Blockly from "blockly";
 import { fireClickOnEnter } from "./util";
 
 import IProjectView = pxt.editor.IProjectView;
@@ -643,10 +644,15 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
     toggleBuiltInHelp(help: pxt.editor.BuiltInHelp, focusIfVisible: boolean) {
         const url = `${builtInPrefix}${help}`;
         if (this.state.docsUrl === url && !this.state.sideDocsCollapsed && !focusIfVisible) {
-            this.toggleVisibility();
-            this.props.parent.editor.focusWorkspace();
+            const wasEditorFocused = Blockly.getFocusManager().getFocusedTree();
+            this.props.parent.setState({ sideDocsCollapsed: true });
+
+            if (!wasEditorFocused) {
+                this.props.parent.editor.focusWorkspace();
+            }
         } else {
             this.openingSideDoc = true;
+            Blockly.hideChaff(true);
             this.setUrl(url);
         }
     }
@@ -661,6 +667,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
     collapse() {
         this.props.parent.setState({ sideDocsCollapsed: true });
+        this.props.parent.editor.focusWorkspace();
     }
 
     isCollapsed() {
@@ -707,6 +714,7 @@ export class SideDocs extends data.Component<SideDocsProps, SideDocsState> {
 
     private handleKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
         if (ev.key == "Escape") {
+            ev.stopPropagation();
             this.collapse();
         }
     }

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -524,7 +524,8 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
             || charCode == 39 /* Right arrow key */
             || charCode == 17 /* Ctrl Key */
             || charCode == 16 /* Shift Key */
-            || charCode == 91 /* Cmd Key */) {
+            || charCode == 91 /* Cmd Key */
+            || charCode == 191 /* Slash Key*/) {
             // Escape tab and shift key
         } else {
             this.setSearch();


### PR DESCRIPTION
When hitting esc on help docs, focus on workspace.

Restore focus on editor parts if focus was on editor when closing help docs. For the toolbox, we ignore slash key in the category keydown handler to avoid focus being moved to search before closing help docs.

Other fixes:
- hideChaff when help docs opens to avoid context menu from overlaying help docs