### PR TITLE
Remove chaff when focus moves outside a dropdown/widget

### DIFF
--- a/pxtblocks/fields/fieldEditorRegistry.ts
+++ b/pxtblocks/fields/fieldEditorRegistry.ts
@@ -98,5 +98,15 @@ export function createFieldEditor(selector: string, text: string, params: any): 
 
     let customField = registeredFieldEditors[selector];
     let instance = new customField.field(text, params, customField.validator);
+    const superShowEditor = instance.showEditor;
+    instance.showEditor = (e?: Event) => {
+        superShowEditor.call(instance, e);
+        const dropDownDiv = Blockly.DropDownDiv.getContentDiv().parentNode;
+        dropDownDiv.addEventListener("focusout", (ev: FocusEvent) => {
+            if (dropDownDiv.contains(ev.relatedTarget as HTMLElement)) return;
+            // Push hideChaff to end of event handlers so any other close handlers complete first
+            setTimeout(() => Blockly.hideChaff(), 0);
+        });
+    }
     return instance;
 }

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -634,6 +634,16 @@ function init(blockInfo: pxtc.BlocksInfo) {
             })
         });
     }
+
+    const widgetDiv = Blockly.WidgetDiv.getDiv();
+
+    widgetDiv.addEventListener("focusout", (e: FocusEvent) => {
+        if (widgetDiv.contains(e.relatedTarget as HTMLElement)) return;
+        // Push hideChaff to end of event handlers so any other close handlers complete first
+        setTimeout(() => {
+            Blockly.hideChaff();
+        }, 0);
+    });
 }
 
 export function initAccessibleBlocksContextMenuItems() {


### PR DESCRIPTION
The issue is that dropdown and widget panes remain open when the user clicks on something outside of Blockly. This adds a smart onFocusOut handler that detects when the focus is no longer within the widget/dropdown, and closes it accordingly.

### To test:

Launch the editor for a widget-based editor (Sound Effect Editor might be the only one affected in Micro:bit?) and then click outside the Blockly workspace. Observe that the widget is dismissed.

Launch the editor for a dropdown-based editor (icon, music note, melody sandbox) and then click outside the Blockly workspace. Observe that the widget is dismissed.

### Implementation:

I have attempted to place the code at a suitably high level that it does not require instrumenting every editor panel individually. However:

1. For widget-based editors, the widget div is created once and never destroyed. We can simply attach the handler to the `Blockly.WidgetDiv`
2. For dropdown-based editors, the dropdown div is destroyed every time `clearContent` is called on it, so I do a little instrumentation to the `CustomFieldEditor`s in `fieldEditorRegistry/createFieldEditor`. This feels a bit hacky, but it's self-contained and it works.

Note that neither the `blocklyDropdownDiv` nor `blocklyWidgetDiv` elements are inside the main Blockly workspace.