### PR TITLE
Inverts keys for left and right in dropdowngrid

### DIFF
--- a/pxtblocks/fields/field_dropdowngrid.ts
+++ b/pxtblocks/fields/field_dropdowngrid.ts
@@ -65,12 +65,14 @@ export abstract class FieldDropdownGrid extends FieldDropdown {
     }
 
     protected addKeyDownHandler(gridItemContainer: HTMLElement) {
+        const nextKey = pxt.Util.isUserLanguageRtl() ? "ArrowLeft" : "ArrowRight";
+        const prevKey = pxt.Util.isUserLanguageRtl() ? "ArrowRight" : "ArrowLeft";
         this.keyDownBinding = Blockly.browserEvents.bind(gridItemContainer, 'keydown', this, (e: KeyboardEvent) => {
             if (this.activeDescendantIndex === undefined) {
-                if (e.code === 'ArrowDown' || e.code === 'ArrowRight' || e.code === 'Home' ) {
+                if (e.code === 'ArrowDown' || e.code === nextKey || e.code === 'Home' ) {
                     this.activeDescendantIndex = 0;
                     return this.setFocusedItem(gridItemContainer, e);
-                } else if (e.code === 'ArrowUp' || e.code === 'ArrowLeft' || e.code === 'End') {
+                } else if (e.code === 'ArrowUp' || e.code === prevKey || e.code === 'End') {
                     this.activeDescendantIndex =  this.gridItems.length - 1;
                     return this.setFocusedItem(gridItemContainer, e);
                 }
@@ -88,12 +90,12 @@ export abstract class FieldDropdownGrid extends FieldDropdown {
                         this.activeDescendantIndex += this.columns_;
                     }
                     break;
-                case 'ArrowRight':
+                case nextKey:
                     if (this.activeDescendantIndex < this.gridItems.length - 1) {
                         this.activeDescendantIndex++;
                     }
                     break;
-                case 'ArrowLeft':
+                case prevKey:
                     if (this.activeDescendantIndex !== 0) {
                         this.activeDescendantIndex--;
                     }


### PR DESCRIPTION
Dropdown grid arrow keys updated to reflect whether the screen has been laid out for a RTL or LTR language. For instance:

**As used in pxt-maqueen**
<img width="271" alt="image" src="https://github.com/user-attachments/assets/0a94d6a9-c4cf-418a-bd29-3163649e99ad" />

**As used in pxt-planetx**
<img width="498" alt="image" src="https://github.com/user-attachments/assets/70748b8c-7920-427f-8e46-148c3c07e2bd" />
 
In both cases, this fix allows the left arrow to move the cursor left, and the right arrow to move it right, when the language is RTL.