### PR TITLE
Improved keyboard focus outlines for various screens

### DIFF
--- a/docfiles/abuse.html
+++ b/docfiles/abuse.html
@@ -17,7 +17,7 @@
         <div class="ui form">
             <div class="field">
                 <label>Why do you find it offensive?</label>
-                <textarea id='abusetext' rows="2"></textarea>
+                <textarea id='abusetext' rows="2" maxlength="1000"></textarea>
             </div>
         </div>
     </div>

--- a/docfiles/script.html
+++ b/docfiles/script.html
@@ -64,7 +64,7 @@
                     <div class="ui form">
                         <div class="field">
                             <label>Why do you find it offensive?</label>
-                            <textarea id='abusetext' rows="2"></textarea>
+                            <textarea id='abusetext' rows="2" maxlength="1000"></textarea>
                         </div>
                     </div>
                 </div>

--- a/multiplayer/src/components/AppModal.tsx
+++ b/multiplayer/src/components/AppModal.tsx
@@ -48,7 +48,7 @@ export default function Render() {
                     <div className="tw-flex tw-flex-col tw-gap-4">
                         <div>{lf("Why do you find it offensive?")}</div>
                         <div>
-                            <Textarea onChange={setTextValue}></Textarea>
+                            <Textarea onChange={setTextValue} maxLength={1000}></Textarea>
                         </div>
                     </div>
                 </ConfirmModal>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-core",
-  "version": "11.4.39",
+  "version": "11.4.40",
   "description": "Microsoft MakeCode provides Blocks / JavaScript / Python tools and editors",
   "keywords": [
     "TypeScript",

--- a/pxtsim/simlib.ts
+++ b/pxtsim/simlib.ts
@@ -933,7 +933,9 @@ namespace pxsim {
             channel.generator = distortion;
             channel.generator.connect(channel.gain);
             source.connect(distortion);
-            channel.gain.gain.value = volume;
+            // scaling the volume to be a multiplier of 0.1
+            // 0.1 is what sounded the best when testing audio recordings against other music blocks
+            channel.gain.gain.value = volume * 0.1;
 
             return audioElement;
         }

--- a/react-common/components/controls/Textarea.tsx
+++ b/react-common/components/controls/Textarea.tsx
@@ -11,6 +11,7 @@ export interface TextareaProps extends ControlProps {
     rows?: number;
     disabled?: boolean;
     minLength?: number;
+    maxLength?: number;
     readOnly?: boolean;
     resize?: "both" | "horizontal" | "vertical";
     wrap?: "hard" | "soft" | "off";
@@ -36,6 +37,7 @@ export const Textarea = (props: TextareaProps) => {
         rows,
         disabled,
         minLength,
+        maxLength,
         readOnly,
         resize,
         wrap,
@@ -130,6 +132,7 @@ export const Textarea = (props: TextareaProps) => {
                     cols={cols}
                     rows={rows}
                     minLength={minLength}
+                    maxLength={maxLength}
                     wrap={wrap}
                     readOnly={!!readOnly}
                     ref={textareaRef}

--- a/react-common/components/theming/themeManager.ts
+++ b/react-common/components/theming/themeManager.ts
@@ -26,6 +26,11 @@ export class ThemeManager {
         return ThemeManager.instances.get(doc);
     }
 
+    public static isCurrentThemeHighContrast(doc: Document = document): boolean {
+        const themeManager = ThemeManager.getInstance(doc);
+        return themeManager.isHighContrast(themeManager.getCurrentColorTheme()?.id);
+    }
+
     public getCurrentColorTheme(): Readonly<pxt.ColorThemeInfo> {
         return this.currentTheme;
     }

--- a/theme/blockly-core.less
+++ b/theme/blockly-core.less
@@ -209,6 +209,9 @@ div.blocklyWidgetDiv {
     position: fixed;
     /* Lower Z index for BlocklyWidgetDiv and grid picker tooltips */
     z-index: @blocklyWidgetDivZIndex;
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 div.blocklyWidgetDiv.functioneditor {
@@ -219,6 +222,9 @@ div.blocklyWidgetDiv.functioneditor {
 div.blocklyDropDownDiv {
     z-index: @blocklyDropdownDivZIndex;
     overflow: hidden;
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 div.blocklyTooltipDiv {

--- a/theme/color-themes/overrides/high-contrast-overrides.css
+++ b/theme/color-themes/overrides/high-contrast-overrides.css
@@ -38,6 +38,13 @@ div.field .ui.toggle.checkbox input:checked~label:before {
     border: 3px solid var(--pxt-colors-yellow-background) !important;
 }
 
+/*
+ * Toolbox
+ */
+.blocklyTreeRow:hover {
+    outline: 3px solid var(--pxt-colors-yellow-background) !important;
+}
+
 /* 
  * Inverted image colors
  */

--- a/theme/common.less
+++ b/theme/common.less
@@ -1074,7 +1074,7 @@ Field editors
                 border-radius: 500rem;
                 padding: 0.7rem 1rem;
 
-                & > i.fas.fa-search {
+                & i.fas.fa-search {
                     position: relative;
                     margin-top: 0.1rem;
                     right: 0;
@@ -1082,6 +1082,25 @@ Field editors
 
                     opacity: .5;
                     transition: opacity 0.3s ease;
+                }
+                & > button:focus-visible {
+                    outline: 3px solid var(--pxt-focus-border);
+                    border-radius: 20%;
+                    &::after {
+                        content: none;
+                    }
+                }
+                &:focus-within {
+                    outline: 3px solid var(--pxt-focus-border);
+                    &:has(button:focus-visible) {
+                        outline: none;
+                    }
+                }
+                &:focus-within::after {
+                    content: none;
+                }
+                & > input:focus {
+                    outline: none !important;
                 }
             }
 
@@ -1158,6 +1177,10 @@ Field editors
             background-color: var(--pxt-neutral-background1-hover) !important;
             color: var(--pxt-neutral-foreground1-hover) !important;
         }
+
+        &:focus-visible {
+            outline: 3px solid var(--pxt-focus-border);
+        }
     }
 
     .extension-grid {
@@ -1197,10 +1220,11 @@ Field editors
         color: @white
     }
 
-    .extension-tag:focus::after  {
-        border: .05rem;
-        border-color: var(--pxt-focus-border);
-        border-radius: 1.6rem;
+    .extension-tag:focus-visible {
+        outline: 3px solid var(--pxt-focus-border);
+        &::after {
+            content: none;
+        }
     }
 
     .tab-header {

--- a/theme/highcontrast.less
+++ b/theme/highcontrast.less
@@ -45,20 +45,20 @@
 @HCaccessibleMenuColor: white;
 
 .hc {
-
-    /* Focus */
-
-    *[tabindex='0'],
+    /*
+    * Generic Focus Highlights
+    */
+    *[tabindex='0']:not(.blocklyWorkspace, .blocklyPassiveFocus, .blocklyTreeInner),
     *[tabindex*='d1'],
     *[tabindex*='d2'], /* Takes items with a defined tabIndex from 0 to 29. */
-    *[role='menuitem'],
+    *[role='menuitem']:not(.editor-menuitem),
     a:not([tabindex='-1']),
     input:not([tabindex='-1']),
     button:not([tabindex='-1']),
     #monacoEditor .blocklyTreeRow,
     #monacoEditor .monacoDraggableBlock {
         &:focus, &:hover {
-            outline: @editorFocusBorderSize solid @selected !important;
+            outline: 3px solid var(--pxt-colors-yellow-background) !important;
         }
     }
 

--- a/theme/serial.less
+++ b/theme/serial.less
@@ -113,6 +113,11 @@
     transition: border-radius 1s ease-in-out;
 }
 
+#serialHeader .button:focus-visible {
+    outline: 3px solid var(--pxt-focus-border);
+    outline-offset: 1px;
+}
+
 #serialConsole,
 #serialCsv {
     margin-top: 0.5rem;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -1089,7 +1089,10 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 return undefined;
             }
 
-            const blockId = this.compilationResult ? pxtblockly.findBlockIdByLine(this.compilationResult.sourceMap, { start: locInfo.line, length: locInfo.endLine - locInfo.line }) : undefined;
+            const blockId = locInfo.functionName === "<main>" /* Root JS function, therefore On Start block */ ?
+                this.editor.getBlocksByType(ts.pxtc.ON_START_TYPE)?.[0]?.id :
+                (this.compilationResult ? pxtblockly.findBlockIdByLine(this.compilationResult.sourceMap, { start: locInfo.line, length: locInfo.endLine - locInfo.line }) : undefined);
+
             if (!blockId) {
                 return undefined;
             }

--- a/webapp/src/container.tsx
+++ b/webapp/src/container.tsx
@@ -16,6 +16,7 @@ import SimState = pxt.editor.SimState;
 import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 import KeyboardControlsHelp from "./components/KeyboardControlsHelp";
 import { CheckboxIcon } from "../../react-common/components/controls/Checkbox";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 // common menu items -- do not remove
 // lf("About")
@@ -322,7 +323,7 @@ export class SettingsMenu extends data.Component<SettingsMenuProps, SettingsMenu
 
     renderCore() {
         const hasIdentity = pxt.auth.hasIdentity();
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         const { greenScreen } = this.state;
         const accessibleBlocks = this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
         const targetTheme = pxt.appTarget.appTheme;

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -340,14 +340,7 @@ export const ENTER_KEY = 13;
 export const SPACE_KEY = 32;
 
 export function getHighContrastOnce(): boolean {
-    // User preference gets priority over theme setting.
-    if (data.getData<boolean>(auth.HIGHCONTRAST)) {
-        return true;
-    }
-
-    const themeManager = ThemeManager.getInstance(document);
-    const currentTheme = themeManager.getCurrentColorTheme();
-    return themeManager.isHighContrast(currentTheme?.id);
+    return ThemeManager.isCurrentThemeHighContrast();
 }
 export function toggleHighContrast() {
     setHighContrast(!getHighContrastOnce())

--- a/webapp/src/dialogs.tsx
+++ b/webapp/src/dialogs.tsx
@@ -688,7 +688,7 @@ export function showReportAbuseAsync(pubId?: string) {
             </div>
             <div className="ui field">
                 <label id="abuseDescriptionLabel">{lf("Why do you find it offensive?")}</label>
-                <textarea aria-labelledby="abuseDescriptionLabel"></textarea>
+                <textarea aria-labelledby="abuseDescriptionLabel" maxLength={1000}></textarea>
             </div>
         </div>,
     }).then(res => {

--- a/webapp/src/headerbar.tsx
+++ b/webapp/src/headerbar.tsx
@@ -13,6 +13,7 @@ import * as projects from "./projects";
 import * as tutorial from "./tutorial";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 type HeaderBarView = "home" | "editor" | "tutorial" | "tutorial-tab" | "debugging" | "sandbox" | "time-machine";
 const LONGPRESS_DURATION = 750;
@@ -240,7 +241,7 @@ export class HeaderBar extends data.Component<ISettingsProps, {}> {
 
     renderCore() {
         const targetTheme = pxt.appTarget.appTheme;
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST);
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         const view = this.getView();
 
         const { home, header, tutorialOptions } = this.props.parent.state;

--- a/webapp/src/monaco.tsx
+++ b/webapp/src/monaco.tsx
@@ -371,13 +371,6 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     private errors: ErrorDisplayInfo[] = [];
     private callLocations: pxtc.LocationInfo[];
 
-    private userPreferencesSubscriber: data.DataSubscriber = {
-        subscriptions: [],
-        onDataChanged: () => {
-            this.onUserPreferencesChanged();
-        }
-    };
-
     private handleFlyoutWheel = (e: WheelEvent) => e.stopPropagation();
     private handleFlyoutScroll = (e: WheelEvent) => e.stopPropagation();
 
@@ -392,14 +385,11 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         this.getDisplayInfoForError = this.getDisplayInfoForError.bind(this);
         this.getErrorHelp = this.getErrorHelp.bind(this);
 
-        data.subscribe(this.userPreferencesSubscriber, auth.HIGHCONTRAST);
-
         ThemeManager.getInstance(document)?.subscribe("monaco", () => this.onUserPreferencesChanged());
     }
 
     onUserPreferencesChanged() {
-        const hc = data.getData<boolean>(auth.HIGHCONTRAST);
-
+        const hc = ThemeManager.isCurrentThemeHighContrast();
         if (this.loadMonacoPromise) this.defineEditorTheme(hc, true);
     }
 

--- a/webapp/src/monacoFlyout.tsx
+++ b/webapp/src/monacoFlyout.tsx
@@ -4,10 +4,10 @@ import * as core from "./core";
 import * as toolbox from "./toolbox";
 import * as workspace from "./workspace";
 import * as data from "./data";
-import * as auth from "./auth";
 import * as pxtblockly from "../../pxtblocks";
 import { HELP_IMAGE_URI } from "../../pxteditor";
 import { getBlockAsText } from "./toolboxHelpers";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import ISettingsProps = pxt.editor.ISettingsProps;
 
@@ -240,7 +240,7 @@ export class MonacoFlyout extends data.Component<MonacoFlyoutProps, MonacoFlyout
     }
 
     protected getBlockStyle = (color: string) => {
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         return {
             backgroundColor: color,
             border: highContrast ? `2px solid ${color}` : "none",

--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -5,18 +5,17 @@ import * as ReactDOM from "react-dom";
 import * as data from "./data";
 import * as sui from "./sui";
 import * as core from "./core";
-import * as cloudsync from "./cloudsync";
 import * as auth from "./auth";
-import * as identity from "./identity";
 import * as codecard from "./codecard"
 import * as carousel from "./carousel";
 import { showAboutDialogAsync } from "./dialogs";
 import { fireClickOnEnter } from "./util";
+import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 import IProjectView = pxt.editor.IProjectView;
 import ISettingsProps = pxt.editor.ISettingsProps;
 import UserInfo = pxt.editor.UserInfo;
-import { sendUpdateFeedbackTheme } from "../../react-common/components/controls/Feedback/FeedbackEventListener";
 
 
 // This Component overrides shouldComponentUpdate, be sure to update that if the state is updated
@@ -301,7 +300,7 @@ export class ProjectSettingsMenu extends data.Component<ProjectSettingsMenuProps
 
     renderCore() {
         const hasIdentity = pxt.auth.hasIdentity();
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast()
         const targetTheme = pxt.appTarget.appTheme;
         // Targets with identity show github user on the profile screen.
         const githubUser = !hasIdentity && this.getData("github:user") as UserInfo;
@@ -1066,7 +1065,7 @@ export class ProjectsDetail extends data.Component<ProjectsDetailProps, Projects
         const { name, description, largeImageUrl, videoUrl,
             youTubeId, youTubePlaylistId, buttonLabel, actionIcon, cardType, tags, otherActions } = this.props;
 
-        const highContrast = this.getData<boolean>(auth.HIGHCONTRAST)
+        const highContrast = ThemeManager.isCurrentThemeHighContrast();
         const tagColors: pxt.Map<string> = pxt.appTarget.appTheme.tagColors || {};
         const descriptions = description && description.split("\n");
         const image = !highContrast && (largeImageUrl || (youTubeId && `https://img.youtube.com/vi/${youTubeId}/0.jpg`));

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -5,9 +5,9 @@ import * as ReactTooltip from 'react-tooltip';
 
 import * as data from "./data";
 import * as core from "./core";
-import * as auth from "./auth";
 import { fireClickOnEnter } from "./util";
 import { focusLastActive } from "../../react-common/components/util";
+import { ThemeManager } from "../../react-common/components/theming/themeManager";
 
 export const appElement = document.getElementById('content');
 
@@ -1311,7 +1311,7 @@ export class Modal extends data.Component<ModalProps, ModalState> {
             'modal transition visible active',
             className
         ]);
-        const hc = this.getData<boolean>(auth.HIGHCONTRAST);
+        const hc = ThemeManager.isCurrentThemeHighContrast();
         const portalClassName = cx([
             hc ? 'hc' : '',
             mountClasses

--- a/webapp/src/toolbox.tsx
+++ b/webapp/src/toolbox.tsx
@@ -632,6 +632,7 @@ export class Toolbox extends data.Component<ToolboxProps, ToolboxState> {
                 }
                 <div className="blocklyTreeRoot">
                     <div
+                        className="blocklyTreeInner"
                         role="tree"
                         tabIndex={0}
                         ref="categoryTree"


### PR DESCRIPTION
### Removed blue focus outlines around Sound Effect and Melody editors

When opened using the mouse.

**Before**

<img width="334" alt="image" src="https://github.com/user-attachments/assets/e17c4efc-9b13-4257-9be9-a189ae143b95" />

<img width="510" alt="image" src="https://github.com/user-attachments/assets/00eb9bc5-8630-4ea4-9b96-cf59f690149c" />

**After**

<img width="305" alt="image" src="https://github.com/user-attachments/assets/04dd39ab-2db4-46db-a8f7-535ac9993c6f" />

<img width="462" alt="image" src="https://github.com/user-attachments/assets/9c6a8e2c-f286-42fe-9428-d1c84a3987e8" />

### Show data screen

**Before**

https://github.com/user-attachments/assets/ee3810f7-d797-4c70-9e33-a0c08b8bff3f

**After**

https://github.com/user-attachments/assets/68ea266e-4ec1-4dd6-8d72-5103b8321098

### Extensions page

**Before**

https://github.com/user-attachments/assets/73782c0e-6d4f-43de-9349-130d46f97fb3

**After**

https://github.com/user-attachments/assets/e24407e4-4673-4bf2-87f9-7b8ed5261e8c

### Extensions page (high contrast)

**Before**

https://github.com/user-attachments/assets/23db2027-b83e-4058-b342-57ce72dea1a6

**After**

https://github.com/user-attachments/assets/3f261ac2-2ed5-44e0-a5cf-3f68b14f3687
