### PR TITLE
Stop simulator from closing dropdowns when restarted from melodyeditor

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -871,6 +871,7 @@ declare namespace pxt.editor {
 
     export interface SimulatorStartOptions {
         clickTrigger?: boolean;
+        background?: boolean;
     }
 
     export interface ImportFileOptions {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -3874,6 +3874,7 @@ export class ProjectView
         pxt.tickEvent('simulator.start');
         const isDebugMatch = !this.debugOptionsChanged();
         const clickTrigger = opts && opts.clickTrigger;
+        const background = opts && opts.background;
         pxt.debug(`start sim (autorun ${this.state.autoRun})`)
         if (!this.shouldStartSimulator() && isDebugMatch || this.state.home) {
             pxt.log("Ignoring call to start simulator, either already running or we shouldn't start.");
@@ -3881,7 +3882,7 @@ export class ProjectView
         }
 
         await this.saveFileAsync();
-        await this.runSimulator({ debug: this.state.debugging, clickTrigger });
+        await this.runSimulator({ debug: this.state.debugging, clickTrigger, background });
     }
 
     debugOptionsChanged() {

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -856,7 +856,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
                 }
                 else {
                     if (shouldRestartSim) {
-                        this.parent.startSimulator();
+                        this.parent.startSimulator({background: true});
                     }
                 }
             }


### PR DESCRIPTION
The melody editor suspends the simulator while it is open, to prevent audio issues. However, restarting contains a call to close any blockly dropdowns, which is a problem if you closed the melody editor by clicking on a dropdown.

This plumbs through the `background` flag to enable the melody editor to restart the simulator without closing any unnecessary dropdowns.

**Before**

https://github.com/user-attachments/assets/a7aa3825-d84e-4716-b3f1-e46cf1939a65

**After**

https://github.com/user-attachments/assets/4f21a8d3-c3c6-4282-8438-3e1e52d5abfd

