### PR TITLE
Fix erroneous option in flyout menu change variable block

### DIFF
--- a/pxtblocks/builtins/variables.ts
+++ b/pxtblocks/builtins/variables.ts
@@ -199,7 +199,7 @@ export function initVariables() {
          * @this Blockly.Block
          */
         customContextMenu: function (this: Blockly.BlockSvg, options: any[]) {
-            if (!(this.workspace?.options?.readOnly)) {
+            if (!(this.workspace?.options?.readOnly) && !this.isInFlyout) {
                 let option: any = {
                     enabled: this.workspace.remainingCapacity() > 0
                 };


### PR DESCRIPTION
It is currently possible to open the context menu for a `Change variable` block and select the `Create [instance of variable]` option, adding an erroneous and persistent instance of the variable to the flyout (see video). This fix simply guards the display of that context menu option.

I have searched the pxt codebase for other uses of custom context menus that could be a problem, and this seems to be the only one affected by this issue. It mirrors a mixin implemented in blockly (`blocks/variables.ts`) for the variable setter and getter blocks- they are already guarded by `!this.isInFlyout`.

**Before**

https://github.com/user-attachments/assets/da5c4ae1-eb7d-470d-93d8-61719703fffe

**After**

https://github.com/user-attachments/assets/0bb0f1dc-c02d-4b1d-aacc-b0660eb12f55



