### PR TITLE
Improve accessibility of melody field editor

### DIFF
--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -3,7 +3,7 @@ import * as Blockly from "blockly";
 interface MatrixDisplayProps {
     cellWidth: number;
     cellHeight: number;
-    cellLabel: string;
+    cellLabel: string | ((value: number) => string);
     cellHorizontalMargin: number;
     cellVerticalMargin: number;
     cornerRadius: number;
@@ -53,7 +53,7 @@ export abstract class FieldMatrix extends Blockly.Field {
                 const cellG = pxsim.svg.child(row, "g", { transform: `translate(${tx} ${ty})`, 'role': 'gridcell' });
                 const rectOptions = {
                     'id': this.getCellId(x,y),  // For aria-activedescendant
-                    'aria-label': cellLabel,
+                    'aria-label': typeof cellLabel === 'string' ? cellLabel : cellLabel(y),
                     'role': 'switch',
                     'aria-checked': "false",
                     'width': scale * cellWidth,

--- a/pxtblocks/fields/field_matrix.ts
+++ b/pxtblocks/fields/field_matrix.ts
@@ -1,9 +1,14 @@
 import * as Blockly from "blockly";
 
+export interface Selection {
+    x: number,
+    y: number,
+}
+
 interface MatrixDisplayProps {
     cellWidth: number;
     cellHeight: number;
-    cellLabel: string | ((value: number) => string);
+    cellLabel: string | ((selection: Selection) => string);
     cellHorizontalMargin: number;
     cellVerticalMargin: number;
     cornerRadius: number;
@@ -53,7 +58,7 @@ export abstract class FieldMatrix extends Blockly.Field {
                 const cellG = pxsim.svg.child(row, "g", { transform: `translate(${tx} ${ty})`, 'role': 'gridcell' });
                 const rectOptions = {
                     'id': this.getCellId(x,y),  // For aria-activedescendant
-                    'aria-label': typeof cellLabel === 'string' ? cellLabel : cellLabel(y),
+                    'aria-label': typeof cellLabel === 'string' ? cellLabel : cellLabel({x, y}),
                     'role': 'switch',
                     'aria-checked': "false",
                     'width': scale * cellWidth,

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -208,6 +208,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
 
         this.playButton = document.createElement("button");
         this.playButton.id = "melody-play-button";
+        this.playButton.ariaLabel = lf("Play melody");
         this.playButton.addEventListener("click", () => this.togglePlay());
 
         this.playIcon = document.createElement("i");

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -485,10 +485,12 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
                 if (this.melody.getValue(row, col)) {
                     pxt.BrowserUtils.removeClass(cell, "melody-default");
                     pxt.BrowserUtils.addClass(cell, rowClass);
+                    cell.setAttribute("aria-checked", "true");
                 }
                 else {
                     pxt.BrowserUtils.addClass(cell, "melody-default");
                     pxt.BrowserUtils.removeClass(cell, rowClass);
+                    cell.setAttribute("aria-checked", "false");
                 }
             }
         }
@@ -575,7 +577,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         this.createMatrixDisplay({
             cellWidth: FieldCustomMelody.CELL_WIDTH,
             cellHeight: FieldCustomMelody.CELL_WIDTH,
-            cellLabel: lf("Note"),
+            cellLabel: (rowNum: number) => lf("Note {0}", pxtmelody.rowToNote(rowNum)),
             cellStroke: "white",
             cellHorizontalMargin: FieldCustomMelody.CELL_HORIZONTAL_MARGIN,
             cellVerticalMargin: FieldCustomMelody.CELL_VERTICAL_MARGIN,

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -4,7 +4,7 @@ import * as Blockly from "blockly";
 
 import svg = pxt.svgUtil;
 import { clearDropDownDiv, FieldCustom, FieldCustomOptions, setMelodyEditorOpen } from "./field_utils";
-import { FieldMatrix } from "./field_matrix";
+import { FieldMatrix, Selection } from "./field_matrix";
 import { BlockSvg } from "blockly";
 export const HEADER_HEIGHT = 50;
 export const TOTAL_WIDTH = 300;
@@ -417,7 +417,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
             this.fieldGroup_.appendChild(cb.el);
         }
 
-        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaLabel = `${notes.every(n => n === "-") ? "empty" : "custom"}, melody`;
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaLabel = notes.every(n => n === "-") ? lf("empty melody") : lf("melody");
     }
 
     private setTempo(tempo: number): void {
@@ -607,7 +607,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         this.createMatrixDisplay({
             cellWidth: FieldCustomMelody.CELL_WIDTH,
             cellHeight: FieldCustomMelody.CELL_WIDTH,
-            cellLabel: (rowNum: number) => lf("Note {0}", pxtmelody.rowToNote(rowNum)),
+            cellLabel: (selection: Selection) => lf("Note {0}", pxtmelody.rowToNote(selection.y)),
             cellStroke: "white",
             cellHorizontalMargin: FieldCustomMelody.CELL_HORIZONTAL_MARGIN,
             cellVerticalMargin: FieldCustomMelody.CELL_VERTICAL_MARGIN,

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -8,6 +8,9 @@ import { FieldMatrix } from "./field_matrix";
 import { BlockSvg } from "blockly";
 export const HEADER_HEIGHT = 50;
 export const TOTAL_WIDTH = 300;
+const melodyContentDivId = "melody-content-div";
+const melodyEditorDivId = "melody-editor-div";
+const melodyGalleryDivId = "melody-editor-gallery";
 
 export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix implements FieldCustom {
     public isFieldCustom_ = true;
@@ -80,13 +83,13 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         Blockly.DropDownDiv.setColour(this.getDropdownBackgroundColour(), this.getDropdownBorderColour());
 
         let contentDiv = Blockly.DropDownDiv.getContentDiv() as HTMLDivElement;
-        contentDiv.id = "melody-content-div";
+        contentDiv.id = melodyContentDivId;
         contentDiv.setAttribute("role", "dialog");
         contentDiv.ariaLabel = lf("Melody editor");
         pxt.BrowserUtils.addClass(contentDiv, "melody-content-div");
         pxt.BrowserUtils.addClass(contentDiv.parentElement, "melody-editor-dropdown");
 
-        this.gallery = new pxtmelody.MelodyGallery();
+        this.gallery = new pxtmelody.MelodyGallery(melodyGalleryDivId);
         this.renderEditor(contentDiv);
 
         this.addKeyboardFocusHandlers();
@@ -157,10 +160,16 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
             this.updateFieldLabel();
         }
 
-        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaHasPopup = 'dialog';
-        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaExpanded = 'false';
-        (this.sourceBlock_ as BlockSvg).getFocusableElement().setAttribute('aria-controls', 'melody-content-div');
+        this.addAriaAtributes();
+    }
 
+    private addAriaAtributes() {
+        // ariaLabel is set in this.updateFieldLabel() as it is content dependent.
+        const el = (this.sourceBlock_ as BlockSvg).getFocusableElement();
+        el.ariaHasPopup = 'dialog';
+        el.ariaExpanded = 'false';
+        el.setAttribute('role', 'button');
+        el.setAttribute('aria-controls', melodyContentDivId);
     }
 
     render_() {
@@ -202,8 +211,8 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         this.editorDiv = document.createElement("div");
         pxt.BrowserUtils.addClass(this.editorDiv, "melody-editor-div");
         this.editorDiv.setAttribute("role", "tabpanel");
-        this.editorDiv.setAttribute("aria-labelledby", "melody-editor-div-control");
-        this.editorDiv.id = "melody-editor-div";
+        this.editorDiv.setAttribute("aria-labelledby", `${melodyEditorDivId}-control`);
+        this.editorDiv.id = melodyEditorDivId;
         this.editorDiv.style.setProperty("background-color", secondaryColor);
 
         this.gridDiv = this.createGridDisplay();
@@ -402,6 +411,8 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
             pxt.BrowserUtils.addClass(cb.el, className);
             this.fieldGroup_.appendChild(cb.el);
         }
+
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaLabel = `${notes.every(n => n === "-") ? "empty" : "custom"}, melody`;
     }
 
     private setTempo(tempo: number): void {
@@ -860,8 +871,8 @@ class Toggle {
         this.leftElement.el.tabIndex = 0;
         this.leftElement.el.ariaSelected = "true";
         this.leftElement.setAttribute("role", "tab");
-        this.leftElement.el.id = "melody-editor-div-control";
-        this.leftElement.el.setAttribute("aria-controls", "melody-editor-div");
+        this.leftElement.el.id = `${melodyEditorDivId}-control`;
+        this.leftElement.el.setAttribute("aria-controls", melodyEditorDivId);
         this.leftText = mkText(this.props.leftText)
             .appendClass("sprite-editor-text")
             .fill(this.props.selectedTextColor);
@@ -874,8 +885,8 @@ class Toggle {
         this.rightElement.el.tabIndex = -1;
         this.rightElement.el.ariaSelected = "false";
         this.rightElement.setAttribute("role", "tab");
-        this.rightElement.el.id = "melody-editor-gallery-control";
-        this.rightElement.el.setAttribute("aria-controls", "melody-editor-gallery-outer");
+        this.rightElement.el.id = `${melodyGalleryDivId}-control`;
+        this.rightElement.el.setAttribute("aria-controls", `${melodyGalleryDivId}-outer`);
         this.rightText = mkText(this.props.rightText)
             .appendClass("sprite-editor-text")
             .fill(this.props.unselectedTextColor);

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -5,6 +5,7 @@ import * as Blockly from "blockly";
 import svg = pxt.svgUtil;
 import { clearDropDownDiv, FieldCustom, FieldCustomOptions, setMelodyEditorOpen } from "./field_utils";
 import { FieldMatrix } from "./field_matrix";
+import { BlockSvg } from "blockly";
 export const HEADER_HEIGHT = 50;
 export const TOTAL_WIDTH = 300;
 
@@ -79,6 +80,9 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         Blockly.DropDownDiv.setColour(this.getDropdownBackgroundColour(), this.getDropdownBorderColour());
 
         let contentDiv = Blockly.DropDownDiv.getContentDiv() as HTMLDivElement;
+        contentDiv.id = "melody-content-div";
+        contentDiv.setAttribute("role", "dialog");
+        contentDiv.ariaLabel = lf("Melody editor");
         pxt.BrowserUtils.addClass(contentDiv, "melody-content-div");
         pxt.BrowserUtils.addClass(contentDiv.parentElement, "melody-editor-dropdown");
 
@@ -108,6 +112,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         if (keyboardTriggered) {
             this.toggle.getRootElement().focus();
         }
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaExpanded = 'true';
     }
 
     getValue() {
@@ -151,6 +156,11 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
             (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot().appendChild(this.fieldGroup_);
             this.updateFieldLabel();
         }
+
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaHasPopup = 'dialog';
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaExpanded = 'false';
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().setAttribute('aria-controls', 'melody-content-div');
+
     }
 
     render_() {
@@ -256,6 +266,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         }
 
         this.prevString = undefined;
+        (this.sourceBlock_ as BlockSvg).getFocusableElement().ariaExpanded = 'false';
     }
 
     // when click done

--- a/pxtblocks/fields/field_melodySandbox.ts
+++ b/pxtblocks/fields/field_melodySandbox.ts
@@ -35,6 +35,7 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
     private bottomDiv: HTMLDivElement;
     private doneButton: HTMLButtonElement;
     private playButton: HTMLButtonElement;
+    private playButtonAriaText: HTMLSpanElement;
     private playIcon: HTMLElement;
     private tempoInput: HTMLInputElement;
     private firstFocusableElement: HTMLElement | SVGElement;
@@ -230,13 +231,17 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
 
         this.playButton = document.createElement("button");
         this.playButton.id = "melody-play-button";
-        this.playButton.ariaLabel = lf("Play melody");
+        this.playButtonAriaText = document.createElement("span");
+        this.playButtonAriaText.classList.add("sr-only");
+        this.playButtonAriaText.textContent = lf("Play melody");
         this.playButton.addEventListener("click", () => this.togglePlay());
 
         this.playIcon = document.createElement("i");
         this.playIcon.id = "melody-play-icon";
+        this.playIcon.ariaHidden = "true";
         pxt.BrowserUtils.addClass(this.playIcon, "play icon");
         this.playButton.appendChild(this.playIcon);
+        this.playButton.appendChild(this.playButtonAriaText);
 
         this.tempoInput = document.createElement("input");
         pxt.BrowserUtils.addClass(this.tempoInput, "ui input");
@@ -695,10 +700,12 @@ export class FieldCustomMelody<U extends FieldCustomOptions> extends FieldMatrix
         if (this.isPlaying) {
             pxt.BrowserUtils.removeClass(this.playIcon, "play icon");
             pxt.BrowserUtils.addClass(this.playIcon, "stop icon");
+            this.playButtonAriaText.textContent = lf("Stop melody");
         }
         else {
             pxt.BrowserUtils.removeClass(this.playIcon, "stop icon");
             pxt.BrowserUtils.addClass(this.playIcon, "play icon");
+            this.playButtonAriaText.textContent = lf("Play melody");
         }
     }
 

--- a/pxtlib/melody-editor/melodyGallery.ts
+++ b/pxtlib/melody-editor/melodyGallery.ts
@@ -240,6 +240,7 @@ namespace pxtmelody {
             const icon = mkElement("i", {
                 className: "music icon melody-icon"
             });
+            addAriaHidden(icon);
 
             const label = mkElement("div", {
                 className: "melody-editor-text"
@@ -276,6 +277,7 @@ namespace pxtmelody {
             const playIcon = mkElement("i", {
                 className: "play icon"
             });
+            addAriaHidden(playIcon);
 
             this.playIcons[i] = playIcon;
 
@@ -416,3 +418,5 @@ namespace pxtmelody {
 }
 
 const getCellId = (x: number, y: number) => `:${y}-${x === 0 ? "selection" : "preview"}`;
+
+const addAriaHidden = (el: HTMLElement) => el.ariaHidden = "true";

--- a/pxtlib/melody-editor/melodyGallery.ts
+++ b/pxtlib/melody-editor/melodyGallery.ts
@@ -254,7 +254,7 @@ namespace pxtmelody {
                 role: "menuitem",
                 title: sample.name,
                 tabIndex: -1,
-                id: getCellId(i, 0)
+                id: getCellId(0, i)
             }, () => this.handleSelection(sample))
 
             leftButton.appendChild(icon);
@@ -270,7 +270,7 @@ namespace pxtmelody {
                 role: "menuitem",
                 title: lf("Preview {0}", sample.name),
                 tabIndex: -1,
-                id: getCellId(i,1)
+                id: getCellId(1, i)
             }, () => this.togglePlay(sample, i));
 
             const playIcon = mkElement("i", {
@@ -415,4 +415,4 @@ namespace pxtmelody {
     }
 }
 
-const getCellId = (x: number, y: number) => `:${x}-${y === 0 ? "selection" : "preview"}`;
+const getCellId = (x: number, y: number) => `:${y}-${x === 0 ? "selection" : "preview"}`;

--- a/pxtlib/melody-editor/melodyGallery.ts
+++ b/pxtlib/melody-editor/melodyGallery.ts
@@ -24,9 +24,12 @@ namespace pxtmelody {
         private focusHandler: (e: FocusEvent) => {} | undefined;
         private blurHandler: (e: FocusEvent) => {} | undefined;
 
+
         constructor() {
             this.containerDiv = document.createElement("div");
             this.containerDiv.setAttribute("id", "melody-editor-gallery-outer");
+            this.containerDiv.setAttribute("role", "tabpanel");
+            this.containerDiv.setAttribute("aria-labelledby", "melody-editor-gallery-control");
             this.contentDiv = document.createElement("div");
             this.contentDiv.setAttribute("id", "melody-editor-gallery");
             this.contentDiv.setAttribute("role", "menu");

--- a/pxtlib/melody-editor/melodyGallery.ts
+++ b/pxtlib/melody-editor/melodyGallery.ts
@@ -25,13 +25,13 @@ namespace pxtmelody {
         private blurHandler: (e: FocusEvent) => {} | undefined;
 
 
-        constructor() {
+        constructor(melodyGalleryDivId: string) {
             this.containerDiv = document.createElement("div");
-            this.containerDiv.setAttribute("id", "melody-editor-gallery-outer");
+            this.containerDiv.setAttribute("id", `${melodyGalleryDivId}-outer`);
             this.containerDiv.setAttribute("role", "tabpanel");
-            this.containerDiv.setAttribute("aria-labelledby", "melody-editor-gallery-control");
+            this.containerDiv.setAttribute("aria-labelledby", `${melodyGalleryDivId}-control`);
             this.contentDiv = document.createElement("div");
-            this.contentDiv.setAttribute("id", "melody-editor-gallery");
+            this.contentDiv.setAttribute("id", melodyGalleryDivId);
             this.contentDiv.setAttribute("role", "menu");
             this.contentDiv.setAttribute("tabindex", "0");
 

--- a/theme/melodyeditor.less
+++ b/theme/melodyeditor.less
@@ -112,9 +112,13 @@
     outline: none;
 }
 
-.melody-editor-toggle-buttons:focus-visible {
+.melody-editor-toggle-buttons:focus-within {
     outline: 3px solid white;
     border-radius: 2px;
+}
+
+.melody-editor-toggle-buttons g {
+    outline: none;
 }
 
 .melody-editor-button {


### PR DESCRIPTION
The changes primarily target improvements to screen reader output.

I'm not sure that the gallery previews are discoverable for screen reader users. We should test and get feedback. We might have to change from menu / menu items to a grid here?