### PR TITLE
Fix screen reader output for create project name input

### DIFF
--- a/webapp/src/projects.tsx
+++ b/webapp/src/projects.tsx
@@ -1468,10 +1468,9 @@ export class ExitAndSaveDialog extends data.Component<ISettingsProps, ExitAndSav
                 closeOnDimmerClick closeOnDocumentClick closeOnEscape
             >
                 <div>
-                    <p>{prompt}</p>
                     <div className="ui form">
                         <sui.Input ref="filenameinput" id={"projectNameInput"}
-                            ariaLabel={prompt} autoComplete={false}
+                            label={prompt} labelWrapperElement="p" autoComplete={false}
                             value={projectName || ''} onChange={this.handleChange} onEnter={this.save}
                             selectOnMount={!mobile} autoFocus={!mobile} />
                     </div>
@@ -1606,10 +1605,9 @@ export class NewProjectDialog extends data.Component<ISettingsProps, NewProjectD
             closeOnDimmerClick closeOnDocumentClick closeOnEscape
         >
             <div>
-                <p>{prompt}</p>
                 <div className="ui form">
                     <sui.Input ref="filenameinput" id={"projectNameInput"}
-                        ariaLabel={prompt} autoComplete={false}
+                        label={prompt} labelWrapperElement="p" autoComplete={false}
                         value={name || ''} onChange={this.handleTextChange} onEnter={this.save}
                         selectOnMount={!mobile} autoFocus={!mobile} />
                 </div>

--- a/webapp/src/sui.tsx
+++ b/webapp/src/sui.tsx
@@ -617,14 +617,16 @@ export function helpIconLink(url: string, title: string) {
 
 export class Field extends data.Component<{
     label?: string;
+    labelWrapperElement?: React.ElementType;
     children?: any;
     ariaLabel?: string;
     htmlFor?: string;
 }, {}> {
     renderCore() {
+        const LabelWrapper = this.props.labelWrapperElement ?? React.Fragment;
         return (
             <div className="field">
-                {this.props.label ? <label htmlFor={!this.props.ariaLabel ? this.props.htmlFor : undefined}>{this.props.label}</label> : null}
+                {this.props.label ? <LabelWrapper><label htmlFor={!this.props.ariaLabel ? this.props.htmlFor : undefined}>{this.props.label}</label></LabelWrapper> : null}
                 {this.props.ariaLabel && this.props.htmlFor ? (<label htmlFor={this.props.htmlFor} className="accessible-hidden">{this.props.ariaLabel}</label>) : ""}
                 {this.props.children}
             </div>
@@ -638,6 +640,7 @@ export class Field extends data.Component<{
 
 export interface InputProps {
     label?: string;
+    labelWrapperElement?: React.ElementType;
     inputLabel?: string;
     class?: string;
     value?: string;
@@ -745,14 +748,14 @@ export class Input extends data.Component<InputProps, InputState> {
 
     renderCore() {
         const p = this.props;
-        const { copy, error, ariaLabel, id, label, inputLabel, lines, autoFocus, placeholder, readOnly, autoComplete } = p;
+        const { copy, error, ariaLabel, id, label, labelWrapperElement, inputLabel, lines, autoFocus, placeholder, readOnly, autoComplete } = p;
         const { value, copied } = this.state;
         const copyBtn = copy && document.queryCommandSupported('copy')
             ? <Button className={`ui right labeled ${copied ? "green" : "primary"} icon button`} text={copied ? lf("Copied!") : lf("Copy")} icon="copy" onClick={this.copy} />
             : null;
 
         return (
-            <Field ariaLabel={ariaLabel} htmlFor={id} label={label}>
+            <Field ariaLabel={ariaLabel} htmlFor={id} label={label} labelWrapperElement={labelWrapperElement}>
                 <div className={"ui input" + (p.inputLabel ? " labelled" : "") + (copy ? " action fluid" : "") + (p.disabled ? " disabled" : "")}>
                     {inputLabel ? (<div className="ui label">{inputLabel}</div>) : ""}
                     {!lines || lines == 1 ? <input


### PR DESCRIPTION
The screen reader reads the paragraph and then the hidden label for the input, but it is the same text. This change wraps the label in a paragraph to retain styling and removes the hidden element.