### PR TITLE
[DO NOT MERGE] Add keyboardcontrols=1 flag to enable testing "on by default"

### DIFF
--- a/localtypings/pxteditor.d.ts
+++ b/localtypings/pxteditor.d.ts
@@ -915,7 +915,7 @@ declare namespace pxt.editor {
         forceUpdate(): void;
 
         reloadEditor(): void;
-        openBlocks(): void;
+        openBlocks(showKeyboardControlsHint?: boolean): void;
         openJavaScript(giveFocusOnLoading?: boolean): void;
         openPython(giveFocusOnLoading?: boolean): void;
         openAssets(): void;

--- a/pxtlib/auth.ts
+++ b/pxtlib/auth.ts
@@ -73,7 +73,7 @@ namespace pxt.auth {
     export const DEFAULT_USER_PREFERENCES: () => UserPreferences = () => ({
         language: pxt.appTarget.appTheme.defaultLocale,
         highContrast: false,
-        accessibleBlocks: false,
+        accessibleBlocks: undefined, // Defaulted at read time depending on flag
         colorThemeIds: {}, // Will lookup pxt.appTarget.appTheme.defaultColorTheme for active target
         reader: "",
         skillmap: { mapProgress: {}, completedTags: {} },

--- a/webapp/src/accessibility.tsx
+++ b/webapp/src/accessibility.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as auth from "./auth";
+import * as core from "./core";
 import * as data from "./data";
 import * as sui from "./sui";
 
@@ -34,7 +35,7 @@ export class EditorAccessibilityMenu extends data.Component<EditorAccessibilityM
     }
 
     openBlocks(e: React.MouseEvent<HTMLElement>) {
-        this.props.parent.openBlocks();
+        this.props.parent.openBlocks(core.isKeyboardControlsByDefault());
     }
 
     openJavaScript() {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -720,8 +720,12 @@ export class ProjectView
         pxt.shell.setEditorLanguagePref("js");
     }
 
-    openBlocks() {
+    openBlocks(showKeyboardControlsHint?: boolean) {
         if (this.updatingEditorFile) return; // already transitioning
+
+        if (showKeyboardControlsHint) {
+            this.blocksEditor.pendingKeyboardControlsHint = true;
+        }
 
         if (this.isBlocksActive()) {
             if (this.state.embedSimView) this.setState({ embedSimView: false });
@@ -5309,6 +5313,9 @@ export class ProjectView
     }
 
     async toggleAccessibleBlocks(eventSource: string) {
+        if (core.isKeyboardControlsByDefault()) {
+            eventSource += "-on-by-default";
+        }
         const nextEnabled = !this.getData<boolean>(auth.ACCESSIBLE_BLOCKS);
         if (nextEnabled) {
             pxt.storage.setLocal("onboardAccessibleBlocks", "1")

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -2985,10 +2985,11 @@ export class ProjectView
                     if (hc) params.set("hc", "1");
                     else params.delete("hc");
                 }
+                // Need to add the URL parameters to the URL for the reload.
+                // Assigning to search will navigate on the first call but reload() needed
+                // for subsequent calls if there's a fragment (e.g. #editor).
                 location.search = params.toString();
-                // .reload refreshes without hitting server so it loses the params,
-                // so have to navigate directly
-                location.assign(location.toString());
+                location.reload();
             } else {
                 location.reload();
             }

--- a/webapp/src/auth.ts
+++ b/webapp/src/auth.ts
@@ -117,7 +117,11 @@ class AuthClient extends pxt.auth.AuthClient {
             // Identity not available, read from local storage
             switch (path) {
                 case HIGHCONTRAST: return /^true$/i.test(pxt.storage.getLocal(HIGHCONTRAST));
-                case ACCESSIBLE_BLOCKS: return /^true$/i.test(pxt.storage.getLocal(ACCESSIBLE_BLOCKS));
+                case ACCESSIBLE_BLOCKS: {
+                    const stored = pxt.storage.getLocal(ACCESSIBLE_BLOCKS);
+                    if (stored == null) return core.isKeyboardControlsByDefault();
+                    return /^true$/i.test(stored);
+                }
                 case COLOR_THEME_IDS: return pxt.U.jsonTryParse(pxt.storage.getLocal(COLOR_THEME_IDS)) as pxt.auth.ColorThemeIdsState;
                 case LANGUAGE: return pxt.storage.getLocal(LANGUAGE);
                 case READER: return pxt.storage.getLocal(READER);
@@ -134,7 +138,7 @@ class AuthClient extends pxt.auth.AuthClient {
             switch (field) {
                 case FIELD_USER_PREFERENCES: return { ...state.preferences };
                 case FIELD_HIGHCONTRAST: return state.preferences?.highContrast ?? pxt.auth.DEFAULT_USER_PREFERENCES().highContrast;
-                case FIELD_KEYBOARD_CONTROLS: return state.preferences?.accessibleBlocks ?? pxt.auth.DEFAULT_USER_PREFERENCES().accessibleBlocks;
+                case FIELD_KEYBOARD_CONTROLS: return state.preferences?.accessibleBlocks ?? core.isKeyboardControlsByDefault();
                 case FIELD_COLOR_THEME_IDS: return state.preferences?.colorThemeIds ?? pxt.auth.DEFAULT_USER_PREFERENCES().colorThemeIds;
                 case FIELD_LANGUAGE: return state.preferences?.language ?? pxt.auth.DEFAULT_USER_PREFERENCES().language;
                 case FIELD_READER: return state.preferences?.reader ?? pxt.auth.DEFAULT_USER_PREFERENCES().reader;

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -60,6 +60,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
     loadingXmlPromise: Promise<any>;
     compilationResult: pxtblockly.BlockCompilationResult;
     shouldFocusWorkspace = false;
+    pendingKeyboardControlsHint = false;
     functionsDialog: CreateFunctionDialog = null;
 
     showCategories: boolean = true;
@@ -1019,7 +1020,20 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         if (accessibleBlocksEnabled) {
             (this.editor.getSvgGroup() as SVGElement).focus();
             Blockly.hideChaff();
+
+            if (this.pendingKeyboardControlsHint) {
+                this.pendingKeyboardControlsHint = false;
+                this.showKeyboardControlsHint();
+            }
         }
+    }
+
+    showKeyboardControlsHint() {
+        if (!this.editor || !Blockly.Msg["HELP_PROMPT"]) return;
+        const isMac = navigator.platform.startsWith("Mac");
+        const shortcut = isMac ? "⌘ /" : lf("Ctrl") + " + /";
+        const message = Blockly.Msg["HELP_PROMPT"].replace("%1", shortcut);
+        Blockly.Toast.show(this.editor, { message, id: "helpHint", oncePerSession: true });
     }
 
     hasUndo() {

--- a/webapp/src/core.ts
+++ b/webapp/src/core.ts
@@ -343,6 +343,13 @@ export function getHighContrastOnce(): boolean {
     return ThemeManager.isCurrentThemeHighContrast();
 }
 
+/**
+ * Returns true if keyboard controls should be enabled by default.
+ */
+export function isKeyboardControlsByDefault(): boolean {
+    return /keyboardcontrols=1/i.test(window.location.href);
+}
+
 export async function toggleAccessibleBlocks(eventSource: string) {
     await setAccessibleBlocks(!data.getData<boolean>(auth.ACCESSIBLE_BLOCKS), eventSource);
 }


### PR DESCRIPTION
This is a temporary flag to enable trialing enabling keyboard controls by default. Micro:bit Educational Foundation are going to do that in their tools that embed MakeCode and provide feedback. This might then be a route to simply enabling them in the next release.

Now that the user isn't naturally exposed to the help by enabling keyboard controls, we show the same help toast as Blockly when the workspace is focused from the skip link. It might be nice to do this in other scenarios (e.g. first tab to the workspace) but that is a riskier change.

There are still some arguable downsides from this flag that we might want to address before making it the default:

- It enables "passive focus" dashed outline around blocks. The purpose of this is to remind the user of the workspace context (which is where e.g. a toolbox block insert will be relative to). But this is more relevant to keyboard users. Passive focus is enabled based on Blocky's logic about whether keyboard navigation has been used which can be a bit hard to predict as a user.

- The active area indicator for the workspace (black focus ring) is also shown for all users. When a user clicks on the workspace background we also indicate that the workspace itself has focus via the yellow ring (as per blocks). We have in the past proposed making this conditional on keyboard navigation being in use (so it feels like focus-visible CSS).

Both intentionally unaddressed for now so we can:

1. reduce risk of this change, which is needed in live MakeCode
2. gather feedback specifically from folks who notice these changes

Another aspect we intend to monitor is feedback from folks who might unintentionally trigger shortcuts.

For telemetry I've intentionally not triggered an event from the default setting and I've tagged the event source for subsequent changes with the fact it was on by default.

Impact on existing users:
1. In the iframe case we only ever persisted the settings to the individual local storage keys when the user changed them, so the flag can change the default for existing users.
2. In the non-iframe/auth case, the defaults (previously false) were proactively persisted so we cannot tell the difference between a user's choice to turn off keyboard controls and the default state, so we respect the persisted setting. This isn't significant for the testing we plan as we'll be using the iframe case.

Warning: if you test this locally settings are in .pxt/storage on disk not browser storage.

Demo: 
https://flag-keyboardcontrols.review-pxt.pages.dev/?keyboardcontrols=1