### PR TITLE
Upgrade Blockly to v13.0.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@zip.js/zip.js": "2.4.20",
     "adm-zip": "^0.5.12",
     "axios": "^1.12.2",
-    "blockly": "13.0.0-beta.5",
+    "blockly": "13.0.0-beta.6",
     "browserify": "17.0.0",
     "chai": "^3.5.0",
     "chalk": "^4.1.2",
@@ -151,10 +151,10 @@
   },
   "overrides": {
     "@blockly/field-grid-dropdown": {
-      "blockly": "13.0.0-beta.5"
+      "blockly": "13.0.0-beta.6"
     },
     "@blockly/plugin-workspace-search": {
-      "blockly": "13.0.0-beta.5"
+      "blockly": "13.0.0-beta.6"
     },
     "combine-source-map": {
       "source-map": "0.4.4"

--- a/pxtblocks/builtins/lists.ts
+++ b/pxtblocks/builtins/lists.ts
@@ -32,7 +32,8 @@ export function initLists() {
                 {
                     "type": "input_value",
                     "name": "VALUE",
-                    "check": ['Array']
+                    "check": ['Array'],
+                    "ariaLabelText": lf("list to check")
                 }
             ],
             "output": 'Number',
@@ -53,12 +54,14 @@ export function initLists() {
                     {
                         "type": "input_value",
                         "name": "LIST",
-                        "check": "Array"
+                        "check": "Array",
+                        "ariaLabelText": lf("list to check")
                     },
                     {
                         "type": "input_value",
                         "name": "INDEX",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("position within list")
                     }
                 ],
                 "colour": pxt.toolbox.blockColors['arrays'],
@@ -84,17 +87,20 @@ export function initLists() {
                     {
                         "type": "input_value",
                         "name": "LIST",
-                        "check": "Array"
+                        "check": "Array",
+                        "ariaLabelText": lf("list to change")
                     },
                     {
                         "type": "input_value",
                         "name": "INDEX",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("position within list")
                     },
                     {
                         "type": "input_value",
                         "name": "VALUE",
-                        "check": null
+                        "check": null,
+                        "ariaLabelText": lf("value to set")
                     }
                 ],
                 "previousStatement": null,

--- a/pxtblocks/builtins/loops.ts
+++ b/pxtblocks/builtins/loops.ts
@@ -25,7 +25,8 @@ export function initLoops() {
                     {
                         "type": "input_value",
                         "name": "COND",
-                        "check": "Boolean"
+                        "check": "Boolean",
+                        "ariaLabelText": lf("condition")
                     }
                 ],
                 "previousStatement": null,
@@ -60,7 +61,8 @@ export function initLoops() {
                     {
                         "type": "input_value",
                         "name": "TO",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("ending number")
                     }
                 ],
                 "previousStatement": null,
@@ -132,7 +134,8 @@ export function initLoops() {
                     {
                         "type": "input_value",
                         "name": "TO",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("ending number")
                     }
                 ],
                 "previousStatement": null,
@@ -291,7 +294,8 @@ export function initLoops() {
                         {
                             "type": "input_value",
                             "name": "LIST",
-                            "check": ["Array", "String"]
+                            "check": ["Array", "String"],
+                            "ariaLabelText": lf("list to iterate over")
                         }
                     ],
                     "previousStatement": null,
@@ -339,7 +343,8 @@ export function initLoops() {
                         {
                             "type": "input_value",
                             "name": "LIST",
-                            "check": "Array"
+                            "check": "Array",
+                            "ariaLabelText": lf("list to iterate over")
                         }
                     ],
                     "previousStatement": null,

--- a/pxtblocks/builtins/math.ts
+++ b/pxtblocks/builtins/math.ts
@@ -29,12 +29,14 @@ export function initMath(blockInfo: pxtc.BlocksInfo) {
                     {
                         "type": "input_value",
                         "name": "x",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("first number")
                     },
                     {
                         "type": "input_value",
                         "name": "y",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("second number")
                     }
                 ],
                 "inputsInline": true,
@@ -69,7 +71,8 @@ export function initMath(blockInfo: pxtc.BlocksInfo) {
                     {
                         "type": "input_value",
                         "name": "x",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("number")
                     }
                 ],
                 "inputsInline": true,
@@ -214,6 +217,10 @@ export function initMathOpBlock() {
     function addArgInput(b: Blockly.Block, second: boolean) {
         const i = b.appendValueInput("ARG" + (second ? 1 : 0));
         i.setCheck("Number");
+        i.setAriaLabelProvider(input =>
+            b.getInput("ARG1")
+                ? (input.name === "ARG0" ? lf("first number") : lf("second number"))
+                : lf("number"));
         if (second) {
             (i.connection as any).setShadowDom(numberShadowDom());
             (i.connection as any).respawnShadow_();
@@ -297,5 +304,6 @@ export function initMathRoundBlock() {
     function addArgInput(b: Blockly.Block) {
         const i = b.appendValueInput("ARG0");
         i.setCheck("Number");
+        i.setAriaLabelProvider(lf("number"));
     }
 }

--- a/pxtblocks/builtins/misc.ts
+++ b/pxtblocks/builtins/misc.ts
@@ -165,7 +165,8 @@ export function initOnStart() {
                         {
                             "type": "input_value",
                             "name": "PREDICATE",
-                            "check": "Boolean"
+                            "check": "Boolean",
+                            "ariaLabelText": lf("condition")
                         }
                     ],
                     "inputsInline": true,

--- a/pxtblocks/builtins/text.ts
+++ b/pxtblocks/builtins/text.ts
@@ -30,7 +30,8 @@ export function initText() {
                 {
                     "type": "input_value",
                     "name": "VALUE",
-                    "check": ['String']
+                    "check": ['String'],
+                    "ariaLabelText": lf("text to check")
                 }
             ],
             "output": 'Number',

--- a/pxtblocks/builtins/variables.ts
+++ b/pxtblocks/builtins/variables.ts
@@ -148,6 +148,7 @@ export function initVariables() {
                     {
                         "type": "input_value",
                         "name": "VALUE",
+                        "ariaLabelText": lf("value to set"),
                     },
                     ],
                     "previousStatement": null,
@@ -180,7 +181,8 @@ export function initVariables() {
                     {
                         "type": "input_value",
                         "name": "VALUE",
-                        "check": "Number"
+                        "check": "Number",
+                        "ariaLabelText": lf("amount to change by")
                     }
                 ],
                 "inputsInline": true,

--- a/pxtblocks/loader.ts
+++ b/pxtblocks/loader.ts
@@ -826,6 +826,7 @@ function initAccessibilityMessages() {
         KEYBOARD_NAV_BLOCK_NAVIGATION_HINT: lf("Use %1 to navigate inside of blocks."),
         KEYBOARD_NAV_WORKSPACE_NAVIGATION_HINT: lf("Use the arrow keys to navigate."),
         KEYBOARD_NAV_FLYOUT_LABEL_HINT: lf("Use the arrow keys to navigate to a block, or press %1 to go to the next heading."),
+        SCREENREADER_HINT: lf("Use the arrow keys to navigate. Press %1 to toggle screenreader accessibility mode."),
         // Aria labels for the workspace tree.
         WORKSPACE_LABEL_1_STACK: lf("Blocks workspace. 1 stack of blocks"),
         WORKSPACE_LABEL_MANY_STACKS: lf("Blocks workspace. %1 stacks of blocks"),
@@ -847,16 +848,28 @@ function initAccessibilityMessages() {
         BLOCK_LABEL_HAS_INPUT: lf("has input"),
         BLOCK_LABEL_HAS_INPUTS: lf("has inputs"),
         BLOCK_LABEL_HAS_BRANCHES: lf("has %1 branches"),
-        BLOCK_LABEL_STATEMENT: lf("{id:block role}command"),
+        BLOCK_LABEL_STATEMENT: lf("{id:block role}statement"),
         BLOCK_LABEL_CONTAINER: lf("{id:block role}container"),
         BLOCK_LABEL_VALUE: lf("{id:block role}value"),
         BLOCK_LABEL_STACK_BLOCKS: lf("%1 stack blocks"),
-        // Aria labels for inputs.
+        // Aria labels for inputs. Only keys read by Blockly's own block code
+        // (for blocks PXT exposes unchanged) belong here; PXT-custom blocks
+        // set aria labels directly via setAriaLabelProvider / ariaLabelText.
         INPUT_LABEL_INDEX: lf("input %1"),
         INPUT_LABEL_VALUE: lf("{id:block position}value position"),
-        INPUT_LABEL_STATEMENT: lf("{id:block position}command position"),
+        INPUT_LABEL_STATEMENT: lf("{id:block position}statement position"),
         INPUT_LABEL_END_STATEMENT: lf("End %1"),
         INPUT_LABEL_EMPTY: lf("Empty"),
+        INPUT_LABEL_VALUE_A: lf("first value"),                  // logic_compare
+        INPUT_LABEL_VALUE_B: lf("second value"),                 // logic_compare
+        INPUT_LABEL_CONDITION_A: lf("first condition"),          // logic_operation
+        INPUT_LABEL_CONDITION_B: lf("second condition"),         // logic_operation
+        INPUT_LABEL_NUMBER_A: lf("first number"),                // math_arithmetic
+        INPUT_LABEL_NUMBER_B: lf("second number"),               // math_arithmetic
+        INPUT_LABEL_MATH_DIVIDEND: lf("dividend"),               // math_modulo
+        INPUT_LABEL_MATH_DIVISOR: lf("divisor"),                 // math_modulo
+        INPUT_LABEL_LOOP_TIMES: lf("number of times to repeat"), // controls_repeat_ext
+        INPUT_LABEL_TEXT_JOIN_ITEM: lf("value %1"),              // text_join
         // Generic aria labels.
         ARIA_LABEL_BUTTON: lf("button"),
         ARIA_LABEL_COMMENT: lf("Comment"),

--- a/pxtblocks/plugins/arrays/createList.ts
+++ b/pxtblocks/plugins/arrays/createList.ts
@@ -210,7 +210,8 @@ const LIST_CREATE_MIXIN = {
         // Add new inputs.
         for (i = 0; i < this.itemCount_; i++) {
             if (!this.getInput('ADD' + i)) {
-                this.appendValueInput('ADD' + i);
+                this.appendValueInput('ADD' + i)
+                    .setAriaLabelProvider(lf("value {0}", i + 1));
             }
         }
         // Remove deleted inputs.


### PR DESCRIPTION
Apply beta.6's en.json delta to initAccessibilityMessages (BLOCK_LABEL_STATEMENT and INPUT_LABEL_STATEMENT renamed "command" -> "statement", plus SCREENREADER_HINT fired from core).

Wire aria input labels on PXT custom blocks via setAriaLabelProvider / ariaLabelText so screen readers announce slots on while/for/for-of/pause-until, variables set/change, list index get/set, list length/create-with, text length, and the custom math min/max/abs/op/round blocks.

Keep only the INPUT_LABEL_* overrides that Blockly's own block code consumes for built-ins PXT exposes unchanged; PXT-custom blocks set their own labels.

@microbit-robert take it or leave it as a starting point, essentially untested, for sure the input label stuff needs checking. Labels for pxt non-TS built-ins are Claude derived from the Blockly ones (not all of which we needed to add as we only use a subset of their blocks).