### PR TITLE
Collapsed block keyboard nav

### DIFF
--- a/pxtblocks/index.ts
+++ b/pxtblocks/index.ts
@@ -23,6 +23,7 @@ export * from "./blockDragger";
 export * from "./workspaceSearch";
 export * from "./monkeyPatches";
 export * from "./getBlockText";
+export * from "./keyboardNav";
 
 import * as contextMenu from "./contextMenu";
 import * as external from "./external";

--- a/pxtblocks/keyboardNav.ts
+++ b/pxtblocks/keyboardNav.ts
@@ -1,0 +1,47 @@
+import * as Blockly from "blockly";
+
+/**
+ * Override of BlockNavigationPolicy that exposes the expand button on
+ * collapsed blocks as a navigable child. Blockly's default treats collapsed
+ * blocks as leaves, leaving the expand icon unreachable by keyboard.
+ */
+export class PxtBlockNavigationPolicy extends Blockly.BlockNavigationPolicy {
+    override getFirstChild(block: Blockly.BlockSvg): Blockly.IFocusableNode | null {
+        if (block.isCollapsed()) {
+            const input = block.getInput(Blockly.constants.COLLAPSED_INPUT_NAME);
+            if (!input) return null;
+            for (const field of input.fieldRow) {
+                if (field.isClickable() || field.isCurrentlyEditable()) {
+                    return field;
+                }
+            }
+            return null;
+        }
+        return super.getFirstChild(block);
+    }
+}
+
+/**
+ * Override of FieldNavigationPolicy that puts fields on the collapsed-block
+ * input on the same row as the block, so the expand button is reachable via
+ * IN (right) rather than NEXT (down).
+ */
+export class PxtFieldNavigationPolicy extends Blockly.FieldNavigationPolicy {
+    override getRowId(current: Blockly.Field<any>): string {
+        const block = current.getSourceBlock();
+        const input = current.getParentInput();
+        if (block?.isCollapsed() && input?.name === Blockly.constants.COLLAPSED_INPUT_NAME) {
+            return (block as Blockly.BlockSvg).getRowId();
+        }
+        return super.getRowId(current);
+    }
+}
+
+export class PxtNavigator extends Blockly.Navigator {
+    constructor() {
+        super();
+        // Prepend so isApplicable() picks our policies before the built-in ones.
+        this.rules.unshift(new PxtBlockNavigationPolicy());
+        this.rules.unshift(new PxtFieldNavigationPolicy());
+    }
+}

--- a/pxtblocks/plugins/functions/utils.ts
+++ b/pxtblocks/plugins/functions/utils.ts
@@ -518,6 +518,7 @@ function createFunctionCallbackFactory_(workspace: Blockly.WorkspaceSvg) {
                 if ((block as (FunctionDefinitionBlock & Blockly.BlockSvg)).afterWorkspaceLoad) {
                     (block as (FunctionDefinitionBlock & Blockly.BlockSvg)).afterWorkspaceLoad();
                 }
+                Blockly.getFocusManager().focusNode(block);
             });
         }
     };

--- a/webapp/src/blocks.tsx
+++ b/webapp/src/blocks.tsx
@@ -753,6 +753,7 @@ export class Editor extends toolboxeditor.ToolboxEditor {
         Blockly.config.snapRadius = 28;
         Blockly.config.connectingSnapRadius = 96;
         this.editor = Blockly.inject(blocklyDiv, this.getBlocklyOptions(forceHasCategories)) as Blockly.WorkspaceSvg;
+        this.editor.setNavigator(new pxtblockly.PxtNavigator());
         pxtblockly.contextMenu.setupWorkspaceContextMenu(this.editor);
 
         // set Blockly Colors


### PR DESCRIPTION
Maybe we push for this in Blockly? They just assume collapsed === leaf.