### PR TITLE
Fix for embedded source in hex files over 64 KiB

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -736,6 +736,7 @@ const lint = lintWithEslint
 const testdecompiler = testTask("decompile-test", "decompilerunner.js");
 const testlang = testTask("compile-test", "compilerunner.js");
 const testhelpers = testTask("helpers-test", "helperrunner.js");
+const testsourceembed = testTask("sourceembed-test", "sourceembedrunner.js");
 const testerr = testTask("errors-test", "errorrunner.js");
 const testfmt = testTask("format-test", "formatrunner.js");
 const testpydecomp = testTask("pydecompile-test", "pydecompilerunner.js");
@@ -773,6 +774,7 @@ const testAll = gulp.series(
     testdecompiler,
     testlang,
     testhelpers,
+    testsourceembed,
     testerr,
     testfmt,
     testpydecomp,
@@ -902,6 +904,7 @@ exports.onlinelearning = onlinelearning;
 exports.tt = teacherTool;
 exports.icons = buildSVGIcons;
 exports.testhelpers = testhelpers;
+exports.testsourceembed = testsourceembed;
 exports.testpxteditor = testpxteditor;
 exports.reactCommon = reactCommon;
 exports.cli = gulp.series(

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1101,9 +1101,11 @@ _stored_program: .hex ${res}
         let res = "\x41\x14\x0E\x2F\xB8\x2F\xA2\xBB"
 
         res += U.uint8ArrayToString([
-            metablob.length & 0xff, metablob.length >> 8,
-            binstring.length & 0xff, binstring.length >> 8,
-            0, 0, 0, 0
+            metablob.length & 0xff, (metablob.length >> 8) & 0xff,
+            // textLen is 32 bits (see docs/source-embedding.md); bytes 14-15 stay reserved
+            binstring.length & 0xff, (binstring.length >> 8) & 0xff,
+            (binstring.length >> 16) & 0xff, (binstring.length >> 24) & 0xff,
+            0, 0
         ])
 
         res += metablob

--- a/pxtcompiler/emitter/hexfile.ts
+++ b/pxtcompiler/emitter/hexfile.ts
@@ -1094,7 +1094,7 @@ _stored_program: .hex ${res}
 `
     }
 
-    function packSource(meta: string, binstring: string) {
+    export function packSource(meta: string, binstring: string) {
         let metablob = Util.toUTF8(meta)
         let totallen = metablob.length + binstring.length
 

--- a/pxtlib/cpp.ts
+++ b/pxtlib/cpp.ts
@@ -1222,7 +1222,8 @@ int main() {
             let m = /^:10....0[0E]41140E2FB82FA2BB(....)(....)(....)(....)(..)/.exec(ln)
             if (m) {
                 metaLen = parseInt(swapBytes(m[1]), 16)
-                textLen = parseInt(swapBytes(m[2]), 16)
+                // textLen is 32 bits (see docs/source-embedding.md): low 16 in m[2], high 16 in m[3]
+                textLen = parseInt(swapBytes(m[2]), 16) + (parseInt(swapBytes(m[3]), 16) << 16)
                 toGo = metaLen + textLen
                 buf = <any>new Uint8Array(toGo)
             } else if (toGo > 0) {

--- a/tests/sourceembed-test/sourceembedrunner.ts
+++ b/tests/sourceembed-test/sourceembedrunner.ts
@@ -1,0 +1,142 @@
+/// <reference path="../../built/pxtcompiler.d.ts"/>
+
+import "mocha";
+import * as chai from "chai";
+
+import * as util from "../common/testUtils";
+
+const assert = chai.assert;
+
+function initGlobals() {
+    let g = global as any
+    g.pxt = pxt;
+    g.ts = ts;
+    g.pxtc = pxtc;
+    g.btoa = (str: string) => Buffer.from(str, "binary").toString("base64");
+    g.atob = (str: string) => Buffer.from(str, "base64").toString("binary");
+}
+
+initGlobals();
+
+// Just needs to exist
+pxt.setAppTarget(util.testAppTarget);
+
+// These tests cover the embedded-source format documented in
+// docs/source-embedding.md: a 16-byte header (8-byte magic, 16-bit JSON
+// header length at offset 8, 32-bit text length at offset 10, reserved
+// zeroes at offset 14) followed by the JSON header and the LZMA-compressed
+// project text, emitted as type-0x0E records at the end of a .hex file.
+
+// the hex emitter masks each char code with 0xff when writing records
+// (see patchHex in pxtcompiler/emitter/hexfile.ts), so read headers the same way
+function headerByte(packed: string, i: number) {
+    return packed.charCodeAt(i) & 0xff
+}
+
+function readMetaLen(packed: string) {
+    return headerByte(packed, 8) | (headerByte(packed, 9) << 8)
+}
+
+function readTextLen(packed: string) {
+    return headerByte(packed, 10) | (headerByte(packed, 11) << 8) |
+        (headerByte(packed, 12) << 16) | (headerByte(packed, 13) << 24)
+}
+
+// deterministic pseudo-random printable text (xorshift32); high-entropy so
+// LZMA cannot compress it much, letting tests control the compressed size
+function pseudoRandomString(len: number): string {
+    let seed = 0xC0FFEE
+    const chars: string[] = []
+    for (let i = 0; i < len; ++i) {
+        seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5; seed |= 0
+        chars.push(String.fromCharCode(0x20 + ((seed >>> 8) % 0x5f)))
+    }
+    return chars.join("")
+}
+
+// mirrors the type-0x0E record emission for bin.packedSource in patchHex
+// (pxtcompiler/emitter/hexfile.ts)
+function embedRecords(packedSource: string): string {
+    const myhex: string[] = []
+    let addr = 0
+    for (let i = 0; i < packedSource.length; i += 16) {
+        const bytes = [0x10, (addr >> 8) & 0xff, addr & 0xff, 0x0E]
+        for (let j = 0; j < 16; ++j)
+            bytes.push((packedSource.charCodeAt(i + j) || 0) & 0xff)
+        myhex.push(ts.pxtc.hexfile.hexBytes(bytes))
+        addr += 16
+    }
+    myhex.push(":00000001FF")
+    return myhex.join("\n")
+}
+
+// compress + pack + emit records + unpack, the way download/import do
+async function roundTripAsync(sourceTextLen: number) {
+    const innerHeader = JSON.stringify({ name: "source embed test" })
+    const source = JSON.stringify({ "main.ts": pseudoRandomString(sourceTextLen) })
+    const compressed = await pxt.lzmaCompressAsync(innerHeader + source)
+    const meta = JSON.stringify({
+        compression: "LZMA",
+        headerSize: innerHeader.length,
+        editor: "tsprj"
+    })
+    const packed = ts.pxtc.packSource(meta, pxt.Util.uint8ArrayToString(compressed))
+    const hex = embedRecords(packed)
+    const unpacked = await pxt.cpp.unpackSourceFromHexAsync(pxt.Util.stringToUint8Array(hex))
+    return { compressedLen: compressed.length, source, unpacked }
+}
+
+describe("embedded source header", () => {
+    const meta = JSON.stringify({ compression: "LZMA", headerSize: 10 })
+
+    it("encodes text lengths below 64 KiB", () => {
+        for (const len of [0, 1, 9152, 0xfffe, 0xffff]) {
+            const packed = ts.pxtc.packSource(meta, pseudoRandomString(len))
+            assert.strictEqual(readMetaLen(packed), meta.length, `metaLen for text length ${len}`)
+            assert.strictEqual(readTextLen(packed), len, `textLen for text length ${len}`)
+        }
+    })
+
+    it("encodes text lengths of 64 KiB and above", () => {
+        // 74688 is the compressed source size of the CreateAI project in
+        // microsoft/pxt-microbit#<issue>; a 16-bit header records it as
+        // 74688 % 65536 == 9152, making the hex impossible to re-import
+        for (const len of [0x10000, 0x10001, 74688, 0x123456]) {
+            const packed = ts.pxtc.packSource(meta, pseudoRandomString(len))
+            assert.strictEqual(readTextLen(packed), len, `textLen for text length ${len}`)
+        }
+    })
+
+    it("keeps the reserved bytes at offset 14 zero", () => {
+        for (const len of [100, 0xffff, 74688]) {
+            const packed = ts.pxtc.packSource(meta, pseudoRandomString(len))
+            assert.strictEqual(headerByte(packed, 14), 0, `reserved byte 14 for text length ${len}`)
+            assert.strictEqual(headerByte(packed, 15), 0, `reserved byte 15 for text length ${len}`)
+        }
+    })
+})
+
+describe("embedded source .hex round-trip", function () {
+    this.timeout(60000)
+
+    // avoid strictEqual on the full sources: a mismatch would print the
+    // entire pseudo-random project as a diff
+    function assertRecovered(r: { compressedLen: number; source: string; unpacked: pxt.cpp.HexFile }) {
+        assert.isOk(r.unpacked, "import recovered nothing")
+        assert.isString(r.unpacked.source, "no source recovered")
+        assert.strictEqual(r.unpacked.source.length, r.source.length, "recovered source length differs")
+        assert.isTrue(r.unpacked.source === r.source, "recovered source content differs from original")
+    }
+
+    it("re-imports a project whose compressed source is below 64 KiB", async () => {
+        const r = await roundTripAsync(30000)
+        assert.isBelow(r.compressedLen, 0x10000, "test precondition: compressed source below 64 KiB")
+        assertRecovered(r)
+    })
+
+    it("re-imports a project whose compressed source exceeds 64 KiB", async () => {
+        const r = await roundTripAsync(120000)
+        assert.isAbove(r.compressedLen, 0x10000, "test precondition: compressed source above 64 KiB")
+        assertRecovered(r)
+    })
+})

--- a/tests/sourceembed-test/tsconfig.json
+++ b/tests/sourceembed-test/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "target": "es2017",
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "declaration": true,
+        "outDir": "../../built/tests",
+        "newLine": "LF",
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es2017",
+            "ES2018.Promise"
+        ],
+        "types": [
+            "chai",
+            "mocha",
+            "node"
+        ],
+        "sourceMap": false,
+        "skipLibCheck": true
+    },
+    "files": [
+        "sourceembedrunner.ts",
+        "../common/testUtils.ts",
+        "../common/testHost.ts"
+    ]
+}


### PR DESCRIPTION
AI generated tests and fix.

Two commits:

- The first adds tests for writing and round tripping embedded source in hex files under and over 64 KiB
    -  embedded source header / encodes text lengths of 64 KiB and above - fails
    - embedded source .hex round-trip / re-imports a project whose compressed source exceeds 64 KiB - fails
- The second commit is the fix

Run `npx gulp cli; npx gulp testsourceembed` to rebuild the bundles used for testing and to run newly added tests in isolation.